### PR TITLE
feat: 이벤트 생성

### DIFF
--- a/src/main/java/com/grepp/spring/app/controller/api/event/EventController.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/event/EventController.java
@@ -4,13 +4,19 @@ import com.grepp.spring.app.controller.api.event.payload.request.CreateEventRequ
 import com.grepp.spring.app.controller.api.event.payload.request.CreateScheduleResultRequest;
 import com.grepp.spring.app.controller.api.event.payload.request.MyTimeScheduleRequest;
 import com.grepp.spring.app.controller.api.event.payload.response.*;
+import com.grepp.spring.app.model.event.service.EventService;
 import com.grepp.spring.infra.error.exceptions.AuthApiException;
+import com.grepp.spring.infra.error.exceptions.NotFoundException;
 import com.grepp.spring.infra.response.ApiResponse;
 import com.grepp.spring.infra.response.ResponseCode;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import javax.security.sasl.AuthenticationException;
@@ -22,22 +28,37 @@ import java.util.List;
 
 @RestController
 @RequestMapping(value = "/api/v1/events", produces = MediaType.APPLICATION_JSON_VALUE)
+@RequiredArgsConstructor
+@Slf4j
 public class EventController {
 
-    // 이벤트 생성
+    private final EventService eventService;
+
     @PostMapping
-    @Operation(summary = "이벤트 생성")
-    public ResponseEntity<ApiResponse<CreateEventResponse>> createEvent(@RequestBody @Valid CreateEventRequest request) {
+    @Operation(summary = "이벤트 생성", description = "그룹 이벤트 또는 일회성 이벤트를 생성합니다.")
+    public ResponseEntity<ApiResponse<Void>> createEvent(@RequestBody @Valid CreateEventRequest request) {
         try {
+            String currentMemberId = extractCurrentMemberId();
+
+            eventService.createEvent(request, currentMemberId);
+
             return ResponseEntity.status(200)
                 .body(ApiResponse.success("이벤트가 성공적으로 생성되었습니다."));
+
+        } catch (AuthApiException e) {
+            log.warn("이벤트 생성 권한 오류: {}", e.getMessage());
+            return ResponseEntity.status(401)
+                .body(ApiResponse.error(ResponseCode.UNAUTHORIZED, e.getMessage()));
+
+        } catch (NotFoundException e) {
+            log.warn("이벤트 생성 시 리소스 없음: {}", e.getMessage());
+            return ResponseEntity.status(404)
+                .body(ApiResponse.error(ResponseCode.NOT_FOUND, e.getMessage()));
+
         } catch (Exception e) {
-            if (e instanceof AuthApiException) {
-                return ResponseEntity.status(401)
-                    .body(ApiResponse.error(ResponseCode.UNAUTHORIZED, "권한이 없습니다."));
-            }
-            return ResponseEntity.status(400)
-                .body(ApiResponse.error(ResponseCode.BAD_REQUEST, "서버가 요청을 처리할 수 없습니다."));
+            log.error("이벤트 생성 중 예상치 못한 오류", e);
+            return ResponseEntity.status(500)
+                .body(ApiResponse.error(ResponseCode.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."));
         }
     }
 
@@ -366,4 +387,17 @@ public class EventController {
                 .body(ApiResponse.error(ResponseCode.BAD_REQUEST, "서버가 요청을 처리할 수 없습니다."));
         }
     }
+
+    private String extractCurrentMemberId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null ||
+            !authentication.isAuthenticated() ||
+            "anonymousUser".equals(authentication.getPrincipal())) {
+            return null;
+        }
+
+        return authentication.getName();
+    }
+
 }

--- a/src/main/java/com/grepp/spring/app/controller/api/event/payload/request/CreateEventRequest.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/event/payload/request/CreateEventRequest.java
@@ -1,41 +1,74 @@
 package com.grepp.spring.app.controller.api.event.payload.request;
 
-import jakarta.validation.constraints.NotNull;
-import lombok.*;
-
-import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Data;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
 
-@Data
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+@Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "이벤트 생성 요청")
 public class CreateEventRequest {
 
-    @NotNull
+    @Schema(description = "이벤트 제목", example = "스터디 모임")
+    @NotBlank(message = "이벤트 제목은 필수입니다.")
+    @Size(max = 10, message = "이벤트 제목은 10자를 초과할 수 없습니다.")
     private String title;
+
+    @Schema(description = "이벤트 설명", example = "매주 화요일 스터디 모임입니다.")
+    @Size(max = 500, message = "이벤트 설명은 500자를 초과할 수 없습니다.")
     private String description;
-    @NotNull
-    private List<DateList> dateList;
-    @NotNull
-    private String type;
-    @NotNull
+
+    @Schema(description = "미팅 타입", example = "ONLINE", allowableValues = {"ONLINE", "OFFLINE"})
+    @NotBlank(message = "미팅 타입은 필수입니다.")
+    @Pattern(regexp = "^(ONLINE|OFFLINE)$", message = "미팅 타입은 ONLINE 또는 OFFLINE이어야 합니다.")
+    private String meetingType;
+
+    @Schema(description = "최대 참여 인원", example = "10")
+    @NotNull(message = "최대 참여 인원은 필수입니다.")
+    @Min(value = 1, message = "최대 참여 인원은 1명 이상이어야 합니다.")
+    @Max(value = 100, message = "최대 참여 인원은 100명을 초과할 수 없습니다.")
     private Integer maxMember;
+
+    @Schema(description = "그룹 ID (그룹 이벤트인 경우만)", example = "1")
+    private Long groupId;
+
+    @Schema(description = "후보 날짜 목록")
+    @NotEmpty(message = "후보 날짜는 최소 1개 이상 필요합니다.")
+    @Valid
+    private List<CandidateDateWeb> dateList;
 
     @Getter
     @Setter
-    public static class DateList {
-        private String date;
-        @NotNull
-        private String startTime;
-        @NotNull
-        private String endTime;
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "후보 날짜 정보")
+    public static class CandidateDateWeb {
 
-        public DateList(String date, String startTime, String endTime) {
-            this.date = date;
-            this.startTime = startTime;
-            this.endTime = endTime;
-        }
+        @Schema(description = "날짜 목록", example = "[\"2025-07-15\", \"2025-07-16\", \"2025-07-17\"]")
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        @NotEmpty(message = "날짜는 최소 1개 이상 필요합니다.")
+        @Valid
+        private List<@NotNull(message = "날짜는 필수입니다.") @FutureOrPresent(message = "과거 날짜는 선택할 수 없습니다.") LocalDate> dates;
+
+        @Schema(description = "시작 시간", example = "09:00")
+        @JsonFormat(pattern = "HH:mm")
+        @NotNull(message = "시작 시간은 필수입니다.")
+        private LocalTime startTime;
+
+        @Schema(description = "종료 시간", example = "18:00")
+        @JsonFormat(pattern = "HH:mm")
+        @NotNull(message = "종료 시간은 필수입니다.")
+        private LocalTime endTime;
     }
 }

--- a/src/main/java/com/grepp/spring/app/controller/api/group/GroupController.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/group/GroupController.java
@@ -26,6 +26,7 @@ import com.grepp.spring.infra.error.exceptions.AuthApiException;
 import com.grepp.spring.infra.response.ApiResponse;
 import com.grepp.spring.infra.response.ResponseCode;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -85,7 +86,7 @@ public class GroupController {
     @Operation(summary = "그룹 생성")
     @PostMapping("/create")
     public ResponseEntity<ApiResponse<CreateGroupResponse>> createGroup(
-        @RequestBody CreateGroupRequest request
+        @Valid @RequestBody CreateGroupRequest request
     ) {
         try {
             // 그룹 생성

--- a/src/main/java/com/grepp/spring/app/controller/api/group/GroupController.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/group/GroupController.java
@@ -1,7 +1,6 @@
 package com.grepp.spring.app.controller.api.group;
 
 
-import com.grepp.spring.app.model.group.dto.GroupDetail;
 import com.grepp.spring.app.model.group.code.GroupRole;
 import com.grepp.spring.app.model.group.dto.GroupSchedule;
 import com.grepp.spring.app.model.group.dto.GroupUser;
@@ -22,6 +21,7 @@ import com.grepp.spring.app.controller.api.group.payload.response.ShowGroupRespo
 import com.grepp.spring.app.controller.api.group.payload.response.ShowGroupScheduleResponse;
 import com.grepp.spring.app.controller.api.group.payload.response.ShowGroupStatisticsResponse;
 import com.grepp.spring.app.controller.api.group.payload.response.WithdrawGroupResponse;
+import com.grepp.spring.app.model.group.service.GroupService;
 import com.grepp.spring.infra.error.exceptions.AuthApiException;
 import com.grepp.spring.infra.response.ApiResponse;
 import com.grepp.spring.infra.response.ResponseCode;
@@ -29,6 +29,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -41,8 +43,13 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
+@Slf4j
 @RequestMapping(value = "/api/v1/groups", produces = MediaType.APPLICATION_JSON_VALUE)
 public class GroupController {
+
+    private final GroupService groupService;
+
 
     // 현재 유저가 속한 그룹 조회
     @GetMapping
@@ -50,18 +57,20 @@ public class GroupController {
     public ResponseEntity<ApiResponse<ShowGroupResponse>> getGroup(
     ) {
         try {
+            groupService.displayGroup();
+
             // Mock Data
-            ShowGroupResponse response = ShowGroupResponse.builder()
-                .groupDetails(new ArrayList<>(List.of(
-                    new GroupDetail(10001L, "한가한 그룹", "매우 졸림, 너무 졸림", 3),
-                    new GroupDetail(10002L, "심심한 그룹", "피곤함 너무 피곤함", 5),
-                    new GroupDetail(10003L, "피곤한 그룹", "이따가 복습해야 함", 6),
-                    new GroupDetail(10004L, "신나는 그룹", "알고리즘 문제 풀어야 하는데", 2),
-                    new GroupDetail(10005L, "즐거운 그룹", "자기소개서 쓰기 귀찮다.", 5),
-                    new GroupDetail(10006L, "빛나는 그룹", "멋쟁이 토마토", 10)
-                )))
-                .build();
-            return ResponseEntity.ok(ApiResponse.success(response));
+            //ShowGroupResponse response = ShowGroupResponse.builder()
+            //    .groupDetails(new ArrayList<>(List.of(
+            //        new GroupDetailDto(10001L, "한가한 그룹", "매우 졸림, 너무 졸림", 3),
+            //        new GroupDetailDto(10002L, "심심한 그룹", "피곤함 너무 피곤함", 5),
+            //        new GroupDetailDto(10003L, "피곤한 그룹", "이따가 복습해야 함", 6),
+            //        new GroupDetailDto(10004L, "신나는 그룹", "알고리즘 문제 풀어야 하는데", 2),
+            //        new GroupDetailDto(10005L, "즐거운 그룹", "자기소개서 쓰기 귀찮다.", 5),
+            //        new GroupDetailDto(10006L, "빛나는 그룹", "멋쟁이 토마토", 10)
+            //    )))
+            //    .build();
+            return ResponseEntity.ok(ApiResponse.noContent());
         } catch (Exception e) {
             if (e instanceof AuthApiException) {
                 return ResponseEntity.status(401)
@@ -79,15 +88,17 @@ public class GroupController {
         @RequestBody CreateGroupRequest request
     ) {
         try {
-            // Mock Data
-            CreateGroupResponse response = CreateGroupResponse.builder()
-                .build();
+            // 그룹 생성
+            groupService.registGroup(request);
+            // 그룹 생성 성공
             return ResponseEntity.ok(ApiResponse.success("그룹이 생성되었습니다."));
         } catch (Exception e) {
+            // 권한 없음: 401
             if (e instanceof AuthApiException) {
                 return ResponseEntity.status(401)
                     .body(ApiResponse.error(ResponseCode.UNAUTHORIZED, "권한이 없습니다."));
             }
+            // 잘못된 요청: 400
             return ResponseEntity.status(400)
                 .body(ApiResponse.error(ResponseCode.BAD_REQUEST, "서버가 요청을 처리할 수 없습니다."));
         }

--- a/src/main/java/com/grepp/spring/app/controller/api/group/payload/request/CreateGroupRequest.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/group/payload/request/CreateGroupRequest.java
@@ -1,5 +1,8 @@
 package com.grepp.spring.app.controller.api.group.payload.request;
 
+import lombok.Getter;
+
+@Getter
 public class CreateGroupRequest {
     private String groupName;
     private String description;

--- a/src/main/java/com/grepp/spring/app/controller/api/group/payload/request/CreateGroupRequest.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/group/payload/request/CreateGroupRequest.java
@@ -1,9 +1,15 @@
 package com.grepp.spring.app.controller.api.group.payload.request;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
 @Getter
 public class CreateGroupRequest {
+    // TODO: groupName 중복 가능한지: 프론트와 협의
+    // TODO: groupName, description 의 문자열 개수 제한: 프론트와 협의
+    // TODO: description nullable: 프론트와 협의
+
+    @NotBlank
     private String groupName;
     private String description;
 

--- a/src/main/java/com/grepp/spring/app/controller/api/group/payload/response/ShowGroupResponse.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/group/payload/response/ShowGroupResponse.java
@@ -1,6 +1,6 @@
 package com.grepp.spring.app.controller.api.group.payload.response;
 
-import com.grepp.spring.app.model.group.dto.GroupDetail;
+import com.grepp.spring.app.model.group.dto.GroupDetailDto;
 import java.util.ArrayList;
 import lombok.Builder;
 import lombok.Data;
@@ -8,5 +8,5 @@ import lombok.Data;
 @Builder
 @Data
 public class ShowGroupResponse {
-    private ArrayList<GroupDetail> groupDetails;
+    private ArrayList<GroupDetailDto> groupDetails;
 }

--- a/src/main/java/com/grepp/spring/app/model/event/code/Role.java
+++ b/src/main/java/com/grepp/spring/app/model/event/code/Role.java
@@ -1,0 +1,6 @@
+package com.grepp.spring.app.model.event.code;
+
+public enum Role {
+    ROLE_MASTER,
+    ROLE_MEMBER
+}

--- a/src/main/java/com/grepp/spring/app/model/event/dto/CandidateDateDto.java
+++ b/src/main/java/com/grepp/spring/app/model/event/dto/CandidateDateDto.java
@@ -18,18 +18,18 @@ public class CandidateDateDto {
     private final LocalTime startTime;
     private final LocalTime endTime;
 
-    public CandidateDate toEntity(Event event) {
+    public static CandidateDate toEntity(CandidateDateDto dto, Event event) {
         CandidateDate candidateDate = new CandidateDate();
         candidateDate.setEvent(event);
-        candidateDate.setDate(this.date);
-        candidateDate.setStartTime(this.startTime);
-        candidateDate.setEndTime(this.endTime);
+        candidateDate.setDate(dto.getDate());
+        candidateDate.setStartTime(dto.getStartTime());
+        candidateDate.setEndTime(dto.getEndTime());
         return candidateDate;
     }
 
-    public static List<CandidateDate> toEntityList(Event event, List<CandidateDateDto> dtoList) {
-        return dtoList.stream()
-            .map(dto -> dto.toEntity(event))
+    public static List<CandidateDate> toEntityList(List<CandidateDateDto> dtos, Event event) {
+        return dtos.stream()
+            .map(dto -> toEntity(dto, event))
             .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/grepp/spring/app/model/event/dto/CandidateDateDto.java
+++ b/src/main/java/com/grepp/spring/app/model/event/dto/CandidateDateDto.java
@@ -1,0 +1,36 @@
+package com.grepp.spring.app.model.event.dto;
+
+import com.grepp.spring.app.model.event.entity.CandidateDate;
+import com.grepp.spring.app.model.event.entity.Event;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+public class CandidateDateDto {
+
+    private final LocalDate date;
+    private final LocalTime startTime;
+    private final LocalTime endTime;
+
+    public CandidateDate toEntity(Event event) {
+        CandidateDate candidateDate = new CandidateDate();
+        candidateDate.setEvent(event);
+        candidateDate.setDate(this.date);
+        candidateDate.setStartTime(this.startTime);
+        candidateDate.setEndTime(this.endTime);
+        return candidateDate;
+    }
+
+    public static List<CandidateDate> toEntityList(Event event, List<CandidateDateDto> dtoList) {
+        return dtoList.stream()
+            .map(dto -> dto.toEntity(event))
+            .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/com/grepp/spring/app/model/event/dto/CreateEventDto.java
+++ b/src/main/java/com/grepp/spring/app/model/event/dto/CreateEventDto.java
@@ -52,18 +52,18 @@ public class CreateEventDto {
             .collect(Collectors.toList());
     }
 
-    public Event toEntity(Group group) {
+    public static Event toEntity(CreateEventDto dto, Group group) {
         return Event.createEvent(
             group,
-            this.title,
-            this.description,
-            this.meetingType,
-            this.maxMember
+            dto.getTitle(),
+            dto.getDescription(),
+            dto.getMeetingType(),
+            dto.getMaxMember()
         );
     }
 
-    public Event toEntity() {
-        return toEntity(null);
+    public static Event toEntity(CreateEventDto dto) {
+        return toEntity(dto, null);
     }
 
 }

--- a/src/main/java/com/grepp/spring/app/model/event/dto/CreateEventDto.java
+++ b/src/main/java/com/grepp/spring/app/model/event/dto/CreateEventDto.java
@@ -1,0 +1,69 @@
+package com.grepp.spring.app.model.event.dto;
+
+import com.grepp.spring.app.controller.api.event.payload.request.CreateEventRequest;
+import com.grepp.spring.app.model.event.code.MeetingType;
+import com.grepp.spring.app.model.event.entity.Event;
+import com.grepp.spring.app.model.group.entity.Group;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+public class CreateEventDto {
+
+    private final String title;
+    private final String description;
+    private final MeetingType meetingType;
+    private final Integer maxMember;
+    private final Long groupId;
+    private final List<CandidateDateDto> candidateDates;
+    private final String currentMemberId;
+
+    public boolean isValid() {
+        return title != null && !title.trim().isEmpty()
+            && meetingType != null
+            && maxMember != null && maxMember > 0
+            && candidateDates != null && !candidateDates.isEmpty();
+    }
+
+    public static CreateEventDto toDto(CreateEventRequest webRequest, String currentMemberId) {
+        return CreateEventDto.builder()
+            .title(webRequest.getTitle())
+            .description(webRequest.getDescription())
+            .meetingType(MeetingType.valueOf(webRequest.getMeetingType()))
+            .maxMember(webRequest.getMaxMember())
+            .groupId(webRequest.getGroupId())
+            .candidateDates(convertCandidateDates(webRequest.getDateList()))
+            .currentMemberId(currentMemberId)
+            .build();
+    }
+
+    private static List<CandidateDateDto> convertCandidateDates(List<CreateEventRequest.CandidateDateWeb> webCandidates) {
+        return webCandidates.stream()
+            .flatMap(webCandidate -> webCandidate.getDates().stream()
+                .map(date -> CandidateDateDto.builder()
+                    .date(date)
+                    .startTime(webCandidate.getStartTime())
+                    .endTime(webCandidate.getEndTime())
+                    .build()))
+            .collect(Collectors.toList());
+    }
+
+    public Event toEntity(Group group) {
+        return Event.createEvent(
+            group,
+            this.title,
+            this.description,
+            this.meetingType,
+            this.maxMember
+        );
+    }
+
+    public Event toEntity() {
+        return toEntity(null);
+    }
+
+}

--- a/src/main/java/com/grepp/spring/app/model/event/dto/EmptyDto.java
+++ b/src/main/java/com/grepp/spring/app/model/event/dto/EmptyDto.java
@@ -1,4 +1,0 @@
-package com.grepp.spring.app.model.event.dto;
-
-public class EmptyDto {
-}

--- a/src/main/java/com/grepp/spring/app/model/event/entity/CandidateDate.java
+++ b/src/main/java/com/grepp/spring/app/model/event/entity/CandidateDate.java
@@ -1,19 +1,12 @@
 package com.grepp.spring.app.model.event.entity;
 
 import com.grepp.spring.infra.entity.BaseEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.SequenceGenerator;
-import jakarta.persistence.Table;
-import java.time.LocalDateTime;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
 
 
 @Entity
@@ -24,23 +17,17 @@ public class CandidateDate extends BaseEntity {
 
     @Id
     @Column(nullable = false, updatable = false)
-    @SequenceGenerator(
-            name = "primary_sequence",
-            sequenceName = "primary_sequence",
-            allocationSize = 1,
-            initialValue = 10000
-    )
-    @GeneratedValue(
-            strategy = GenerationType.SEQUENCE,
-            generator = "primary_sequence"
-    )
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column
-    private LocalDateTime startTime;
+    @Column(nullable = false)
+    private LocalDate date;
 
     @Column(nullable = false)
-    private LocalDateTime endTime;
+    private LocalTime startTime;
+
+    @Column(nullable = false)
+    private LocalTime endTime;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "event_id")

--- a/src/main/java/com/grepp/spring/app/model/event/entity/Event.java
+++ b/src/main/java/com/grepp/spring/app/model/event/entity/Event.java
@@ -3,17 +3,10 @@ package com.grepp.spring.app.model.event.entity;
 import com.grepp.spring.app.model.event.code.MeetingType;
 import com.grepp.spring.app.model.group.entity.Group;
 import com.grepp.spring.infra.entity.BaseEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.SequenceGenerator;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 
@@ -21,20 +14,12 @@ import lombok.Setter;
 @Table(name = "Events")
 @Getter
 @Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Event extends BaseEntity {
 
     @Id
     @Column(nullable = false, updatable = false)
-    @SequenceGenerator(
-            name = "primary_sequence",
-            sequenceName = "primary_sequence",
-            allocationSize = 1,
-            initialValue = 10000
-    )
-    @GeneratedValue(
-            strategy = GenerationType.SEQUENCE,
-            generator = "primary_sequence"
-    )
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(nullable = false)
@@ -44,6 +29,7 @@ public class Event extends BaseEntity {
     private String description;
 
     @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
     private MeetingType meetingType;
 
     @Column(nullable = false)
@@ -52,5 +38,51 @@ public class Event extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "group_id")
     private Group group;
+
+    private Event(Group group, String title, String description,
+                  MeetingType meetingType, Integer maxMember) {
+        validateForCreation(title, meetingType, maxMember);
+
+        this.group = group;
+        this.title = title;
+        this.description = description;
+        this.meetingType = meetingType;
+        this.maxMember = maxMember;
+    }
+
+    public static Event createEvent(Group group, String title, String description,
+                                    MeetingType meetingType, Integer maxMember) {
+        return new Event(group, title, description, meetingType, maxMember);
+    }
+
+    private static void validateForCreation(String title, MeetingType meetingType, Integer maxMember) {
+        validateTitle(title);
+        validateMeetingType(meetingType);
+        validateMaxMember(maxMember);
+    }
+
+    private static void validateTitle(String title) {
+        if (title == null || title.trim().isEmpty()) {
+            throw new IllegalArgumentException("이벤트 제목은 필수입니다.");
+        }
+        if (title.length() > 10) {
+            throw new IllegalArgumentException("이벤트 제목은 10자를 초과할 수 없습니다.");
+        }
+    }
+
+    private static void validateMeetingType(MeetingType meetingType) {
+        if (meetingType == null) {
+            throw new IllegalArgumentException("미팅 타입은 필수입니다.");
+        }
+    }
+
+    private static void validateMaxMember(Integer maxMember) {
+        if (maxMember == null || maxMember <= 0) {
+            throw new IllegalArgumentException("최대 인원은 1명 이상이어야 합니다.");
+        }
+        if (maxMember > 100) {
+            throw new IllegalArgumentException("최대 인원은 100명을 초과할 수 없습니다.");
+        }
+    }
 
 }

--- a/src/main/java/com/grepp/spring/app/model/event/entity/EventMember.java
+++ b/src/main/java/com/grepp/spring/app/model/event/entity/EventMember.java
@@ -1,17 +1,9 @@
 package com.grepp.spring.app.model.event.entity;
 
+import com.grepp.spring.app.model.event.code.Role;
 import com.grepp.spring.app.model.member.entity.Member;
 import com.grepp.spring.infra.entity.BaseEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.SequenceGenerator;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -24,20 +16,12 @@ public class EventMember extends BaseEntity {
 
     @Id
     @Column(nullable = false, updatable = false)
-    @SequenceGenerator(
-            name = "primary_sequence",
-            sequenceName = "primary_sequence",
-            allocationSize = 1,
-            initialValue = 10000
-    )
-    @GeneratedValue(
-            strategy = GenerationType.SEQUENCE,
-            generator = "primary_sequence"
-    )
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(nullable = false)
-    private String role;
+    @Enumerated(EnumType.STRING)
+    private Role role;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")

--- a/src/main/java/com/grepp/spring/app/model/event/entity/TempSchedule.java
+++ b/src/main/java/com/grepp/spring/app/model/event/entity/TempSchedule.java
@@ -1,19 +1,11 @@
 package com.grepp.spring.app.model.event.entity;
 
 import com.grepp.spring.infra.entity.BaseEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.SequenceGenerator;
-import jakarta.persistence.Table;
-import java.time.LocalDateTime;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
+
+import java.time.LocalDateTime;
 
 
 @Entity
@@ -24,16 +16,7 @@ public class TempSchedule extends BaseEntity {
 
     @Id
     @Column(nullable = false, updatable = false)
-    @SequenceGenerator(
-            name = "primary_sequence",
-            sequenceName = "primary_sequence",
-            allocationSize = 1,
-            initialValue = 10000
-    )
-    @GeneratedValue(
-            strategy = GenerationType.SEQUENCE,
-            generator = "primary_sequence"
-    )
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(nullable = false)

--- a/src/main/java/com/grepp/spring/app/model/event/repository/CandidateDateRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/event/repository/CandidateDateRepository.java
@@ -1,0 +1,8 @@
+package com.grepp.spring.app.model.event.repository;
+
+import com.grepp.spring.app.model.event.entity.CandidateDate;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CandidateDateRepository extends JpaRepository<CandidateDate, Long> {
+
+}

--- a/src/main/java/com/grepp/spring/app/model/event/repository/EmptyRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/event/repository/EmptyRepository.java
@@ -1,4 +1,0 @@
-package com.grepp.spring.app.model.event.repository;
-
-public class EmptyRepository {
-}

--- a/src/main/java/com/grepp/spring/app/model/event/repository/EventMemberRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/event/repository/EventMemberRepository.java
@@ -1,0 +1,8 @@
+package com.grepp.spring.app.model.event.repository;
+
+import com.grepp.spring.app.model.event.entity.EventMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EventMemberRepository extends JpaRepository<EventMember, Long> {
+
+}

--- a/src/main/java/com/grepp/spring/app/model/event/repository/EventRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/event/repository/EventRepository.java
@@ -1,0 +1,12 @@
+package com.grepp.spring.app.model.event.repository;
+
+import com.grepp.spring.app.model.event.entity.Event;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+public interface EventRepository extends JpaRepository<Event, Long> {
+
+
+}

--- a/src/main/java/com/grepp/spring/app/model/event/repository/GroupMemberRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/event/repository/GroupMemberRepository.java
@@ -1,0 +1,12 @@
+package com.grepp.spring.app.model.event.repository;
+
+import com.grepp.spring.app.model.group.entity.GroupMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> {
+
+    Optional<GroupMember> findByGroupIdAndMemberId(Long groupId, String memberId);
+
+}

--- a/src/main/java/com/grepp/spring/app/model/event/repository/GroupRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/event/repository/GroupRepository.java
@@ -1,0 +1,12 @@
+package com.grepp.spring.app.model.event.repository;
+
+import com.grepp.spring.app.model.group.entity.Group;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface GroupRepository extends JpaRepository<Group, Long> {
+
+    Optional<Group> findById(Long id);
+
+}

--- a/src/main/java/com/grepp/spring/app/model/event/service/EmptyService.java
+++ b/src/main/java/com/grepp/spring/app/model/event/service/EmptyService.java
@@ -1,4 +1,0 @@
-package com.grepp.spring.app.model.event.service;
-
-public class EmptyService {
-}

--- a/src/main/java/com/grepp/spring/app/model/event/service/EventService.java
+++ b/src/main/java/com/grepp/spring/app/model/event/service/EventService.java
@@ -1,0 +1,101 @@
+package com.grepp.spring.app.model.event.service;
+
+import com.grepp.spring.app.controller.api.event.payload.request.CreateEventRequest;
+import com.grepp.spring.app.model.event.code.Role;
+import com.grepp.spring.app.model.event.dto.CandidateDateDto;
+import com.grepp.spring.app.model.event.dto.CreateEventDto;
+import com.grepp.spring.app.model.event.entity.CandidateDate;
+import com.grepp.spring.app.model.event.entity.Event;
+import com.grepp.spring.app.model.event.entity.EventMember;
+import com.grepp.spring.app.model.event.repository.*;
+import com.grepp.spring.app.model.group.entity.Group;
+import com.grepp.spring.app.model.group.entity.GroupMember;
+import com.grepp.spring.app.model.member.entity.Member;
+import com.grepp.spring.infra.error.exceptions.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class EventService {
+
+    private final EventRepository eventRepository;
+    private final EventMemberRepository eventMemberRepository;
+    private final CandidateDateRepository candidateDateRepository;
+    // TODO: Member 패키지의 MemberRepository에 findById 메서드가 추가될 시, 주석 해제
+//    private final MemberRepository memberRepository;
+    // TODO: 추후 Event 패키지의 GroupRepository로 변경해야 함. 현재는 Event 패키지의 GroupRepository임
+    private final GroupRepository groupRepository;
+    private final GroupMemberRepository groupMemberRepository;
+
+    @Transactional
+    public void createEvent(CreateEventRequest webRequest, String currentMemberId) {
+        CreateEventDto serviceRequest = CreateEventDto.toDto(webRequest, currentMemberId);
+
+        validate(serviceRequest);
+
+        Event event = null;
+
+        if (serviceRequest.getGroupId() != null) {
+            Group group = groupRepository.findById(serviceRequest.getGroupId())
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 그룹입니다. ID: " + serviceRequest.getGroupId()));
+
+            GroupMember groupMember = groupMemberRepository.findByGroupIdAndMemberId(serviceRequest.getGroupId(), currentMemberId)
+                .orElseThrow(() -> new NotFoundException("그룹에 속하지 않은 회원입니다. 그룹ID: " + serviceRequest.getGroupId()));
+
+            event = serviceRequest.toEntity(group);
+        } else {
+            event = serviceRequest.toEntity();
+        }
+
+        event = eventRepository.save(event);
+        // TODO: Member 패키지의 MemberRepository에 findById 메서드가 추가될 시, 주석 해제
+//        createMasterMember(event, serviceRequest.getCurrentMemberId());
+        createCandidateDates(event, serviceRequest.getCandidateDates());
+    }
+
+    // TODO: Member 패키지의 MemberRepository에 findById 메서드가 추가될 시, 주석 해제
+//    private void createMasterMember(Event event, String memberId) {
+//        Member member = memberRepository.findById(memberId)
+//            .orElseThrow(() -> new NotFoundException("존재하지 않는 회원입니다. ID: " + memberId));
+//
+//        EventMember eventMember = new EventMember();
+//        eventMember.setEvent(event);
+//        eventMember.setMember(member);
+//        eventMember.setRole(Role.ROLE_MASTER);
+//
+//        eventMemberRepository.save(eventMember);
+//        log.debug("마스터 멤버 생성 완료 - 회원ID: {}", memberId);
+//    }
+
+    private void createCandidateDates(Event event, List<CandidateDateDto> candidateDates) {
+        List<CandidateDate> entities = CandidateDateDto.toEntityList(event, candidateDates);
+        candidateDateRepository.saveAll(entities);
+        log.debug("후보 날짜 생성 완료 - 개수: {}", entities.size());
+    }
+
+    private void validate(CreateEventDto serviceRequest) {
+        if (!serviceRequest.isValid()) {
+            throw new IllegalArgumentException("유효하지 않은 이벤트 생성 요청입니다.");
+        }
+
+        validateCandidateDates(serviceRequest.getCandidateDates());
+
+        // TODO: 비즈니스 규칙 추가
+        // 이벤트 제한 검증 (예: 최대 인원, 그룹 권한 등)
+    }
+
+    private void validateCandidateDates(List<CandidateDateDto> candidateDates) {
+        if (candidateDates == null || candidateDates.isEmpty()) {
+            throw new IllegalArgumentException("후보 날짜는 최소 1개 이상 필요합니다.");
+        }
+        // TODO: 추가 검증 로직 구현
+    }
+
+}

--- a/src/main/java/com/grepp/spring/app/model/event/service/EventService.java
+++ b/src/main/java/com/grepp/spring/app/model/event/service/EventService.java
@@ -49,9 +49,9 @@ public class EventService {
             GroupMember groupMember = groupMemberRepository.findByGroupIdAndMemberId(serviceRequest.getGroupId(), currentMemberId)
                 .orElseThrow(() -> new NotFoundException("그룹에 속하지 않은 회원입니다. 그룹ID: " + serviceRequest.getGroupId()));
 
-            event = serviceRequest.toEntity(group);
+            event = CreateEventDto.toEntity(serviceRequest, group);
         } else {
-            event = serviceRequest.toEntity();
+            event = CreateEventDto.toEntity(serviceRequest);
         }
 
         event = eventRepository.save(event);
@@ -75,7 +75,7 @@ public class EventService {
 //    }
 
     private void createCandidateDates(Event event, List<CandidateDateDto> candidateDates) {
-        List<CandidateDate> entities = CandidateDateDto.toEntityList(event, candidateDates);
+        List<CandidateDate> entities = CandidateDateDto.toEntityList(candidateDates, event);
         candidateDateRepository.saveAll(entities);
         log.debug("후보 날짜 생성 완료 - 개수: {}", entities.size());
     }

--- a/src/main/java/com/grepp/spring/app/model/group/dto/GroupCreateDto.java
+++ b/src/main/java/com/grepp/spring/app/model/group/dto/GroupCreateDto.java
@@ -1,0 +1,38 @@
+package com.grepp.spring.app.model.group.dto;
+
+import com.grepp.spring.app.controller.api.group.payload.request.CreateGroupRequest;
+import com.grepp.spring.app.model.group.entity.Group;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class GroupCreateDto {
+
+    private String name;
+    private String description;
+
+    // request로 GroupCreateDto 생성하는 생성자
+    public GroupCreateDto(CreateGroupRequest request){
+        this.name = request.getGroupName();
+        this.description = request.getDescription();
+    }
+
+    // request to Dto
+    public static GroupCreateDto toDto(CreateGroupRequest request){
+        return new GroupCreateDto(request);
+    }
+
+    // Dto to Entity
+    public static Group toEntity(GroupCreateDto groupCreateDto){
+        Group group = new Group();
+        group.setName(groupCreateDto.getName());
+        group.setDescription(groupCreateDto.getDescription());
+        group.setIsGrouped(true);
+        return group;
+    }
+
+
+}

--- a/src/main/java/com/grepp/spring/app/model/group/dto/GroupDetailDto.java
+++ b/src/main/java/com/grepp/spring/app/model/group/dto/GroupDetailDto.java
@@ -5,7 +5,7 @@ import lombok.Data;
 
 @Data
 @AllArgsConstructor
-public class GroupDetail {
+public class GroupDetailDto {
     private Long groupId;
     private String groupName;
     private String description;

--- a/src/main/java/com/grepp/spring/app/model/group/dto/GroupMemberCreateDto.java
+++ b/src/main/java/com/grepp/spring/app/model/group/dto/GroupMemberCreateDto.java
@@ -11,6 +11,7 @@ public class GroupMemberCreateDto {
         GroupMember groupMember = new GroupMember();
         groupMember.setGroup(group);
         groupMember.setMember(member);
+        groupMember.setGroupAdmin(true);
         groupMember.setRole(GroupRole.GROUP_LEADER);
 
         return groupMember;

--- a/src/main/java/com/grepp/spring/app/model/group/dto/GroupMemberCreateDto.java
+++ b/src/main/java/com/grepp/spring/app/model/group/dto/GroupMemberCreateDto.java
@@ -1,0 +1,19 @@
+package com.grepp.spring.app.model.group.dto;
+
+import com.grepp.spring.app.model.group.code.GroupRole;
+import com.grepp.spring.app.model.group.entity.Group;
+import com.grepp.spring.app.model.group.entity.GroupMember;
+import com.grepp.spring.app.model.member.entity.Member;
+
+public class GroupMemberCreateDto {
+
+    public static GroupMember toEntity(Group group, Member member){
+        GroupMember groupMember = new GroupMember();
+        groupMember.setGroup(group);
+        groupMember.setMember(member);
+        groupMember.setRole(GroupRole.GROUP_LEADER);
+
+        return groupMember;
+    }
+
+}

--- a/src/main/java/com/grepp/spring/app/model/group/entity/GroupMember.java
+++ b/src/main/java/com/grepp/spring/app/model/group/entity/GroupMember.java
@@ -1,5 +1,6 @@
 package com.grepp.spring.app.model.group.entity;
 
+import com.grepp.spring.app.model.group.code.GroupRole;
 import com.grepp.spring.app.model.member.entity.Member;
 import com.grepp.spring.infra.entity.BaseEntity;
 import jakarta.persistence.Column;
@@ -37,7 +38,7 @@ public class GroupMember extends BaseEntity {
     private Long id;
 
     @Column(nullable = false)
-    private String role;
+    private GroupRole role;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")

--- a/src/main/java/com/grepp/spring/app/model/group/entity/GroupMember.java
+++ b/src/main/java/com/grepp/spring/app/model/group/entity/GroupMember.java
@@ -5,6 +5,8 @@ import com.grepp.spring.app.model.member.entity.Member;
 import com.grepp.spring.infra.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -38,6 +40,7 @@ public class GroupMember extends BaseEntity {
     private Long id;
 
     @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
     private GroupRole role;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -48,4 +51,5 @@ public class GroupMember extends BaseEntity {
     @JoinColumn(name = "group_id")
     private Group group;
 
+    private Boolean groupAdmin;
 }

--- a/src/main/java/com/grepp/spring/app/model/group/repository/EmptyRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/group/repository/EmptyRepository.java
@@ -1,0 +1,5 @@
+package com.grepp.spring.app.model.group.repository;
+
+public class EmptyRepository {
+
+}

--- a/src/main/java/com/grepp/spring/app/model/group/repository/EmptyRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/group/repository/EmptyRepository.java
@@ -1,5 +1,0 @@
-package com.grepp.spring.app.model.group.repository;
-
-public class EmptyRepository {
-
-}

--- a/src/main/java/com/grepp/spring/app/model/group/repository/GroupMemberRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/group/repository/GroupMemberRepository.java
@@ -1,0 +1,10 @@
+package com.grepp.spring.app.model.group.repository;
+
+import com.grepp.spring.app.model.group.entity.GroupMember;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> {
+
+    List<GroupMember> findByMemberId(String memberId);
+}

--- a/src/main/java/com/grepp/spring/app/model/group/repository/GroupRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/group/repository/GroupRepository.java
@@ -1,0 +1,9 @@
+package com.grepp.spring.app.model.group.repository;
+
+import com.grepp.spring.app.model.group.entity.Group;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GroupRepository extends JpaRepository<Group, Long> {
+
+
+}

--- a/src/main/java/com/grepp/spring/app/model/group/service/EmptyService.java
+++ b/src/main/java/com/grepp/spring/app/model/group/service/EmptyService.java
@@ -1,0 +1,5 @@
+package com.grepp.spring.app.model.group.service;
+
+public class EmptyService {
+
+}

--- a/src/main/java/com/grepp/spring/app/model/group/service/EmptyService.java
+++ b/src/main/java/com/grepp/spring/app/model/group/service/EmptyService.java
@@ -1,5 +1,0 @@
-package com.grepp.spring.app.model.group.service;
-
-public class EmptyService {
-
-}

--- a/src/main/java/com/grepp/spring/app/model/group/service/GroupService.java
+++ b/src/main/java/com/grepp/spring/app/model/group/service/GroupService.java
@@ -64,6 +64,6 @@ public class GroupService {
         GroupMember groupMember = GroupMemberCreateDto.toEntity(group, member);
         groupMemberRepository.save(groupMember);
         log.info("그룹-멤버 생성");
-        }
+    }
 
 }

--- a/src/main/java/com/grepp/spring/app/model/group/service/GroupService.java
+++ b/src/main/java/com/grepp/spring/app/model/group/service/GroupService.java
@@ -1,0 +1,75 @@
+package com.grepp.spring.app.model.group.service;
+
+import com.grepp.spring.app.controller.api.group.payload.request.CreateGroupRequest;
+import com.grepp.spring.app.model.auth.domain.Principal;
+import com.grepp.spring.app.model.group.dto.GroupCreateDto;
+import com.grepp.spring.app.model.group.dto.GroupMemberCreateDto;
+import com.grepp.spring.app.model.group.entity.Group;
+import com.grepp.spring.app.model.group.entity.GroupMember;
+import com.grepp.spring.app.model.group.repository.GroupMemberRepository;
+import com.grepp.spring.app.model.group.repository.GroupRepository;
+import com.grepp.spring.app.model.member.entity.Member;
+import com.grepp.spring.app.model.member.repository.MemberRepository;
+import com.grepp.spring.infra.error.exceptions.CommonException;
+import com.grepp.spring.infra.response.ResponseCode;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.modelmapper.ModelMapper;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class GroupService {
+
+    private final GroupRepository groupRepository;
+    private final GroupMemberRepository groupMemberRepository;
+    private final MemberRepository memberRepository;
+    private final ModelMapper mapper;
+
+    // 그룹 조회
+    public void displayGroup(){
+        // http 요청 사용자 조회
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Principal user = (Principal) authentication.getPrincipal();
+        Member member = memberRepository.findById(user.getUsername()).orElseThrow();
+        log.info("멤버 조회");
+        List<GroupMember> groupMember = groupMemberRepository.findByMemberId(member.getId());
+        for (GroupMember groupMember1: groupMember){
+
+            System.out.println(groupMember1.getGroup().getId());
+        }
+    }
+
+    // 그룹 생성
+    @Transactional
+    public void registGroup(CreateGroupRequest request){
+        try{
+
+            // 그룹 생성
+            GroupCreateDto groupCreateDto = GroupCreateDto.toDto(request);
+            Group group = GroupCreateDto.toEntity(groupCreateDto);
+            groupRepository.save(group);
+            log.info("그룹생성");
+
+            // http 요청 사용자 조회
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            Principal user = (Principal) authentication.getPrincipal();
+            Member member = memberRepository.findById(user.getUsername()).orElseThrow();
+            log.info("멤버 조회");
+
+            // 그룹-멤버 생성 (중간 테이블)
+            GroupMember groupMember = GroupMemberCreateDto.toEntity(group, member);
+            groupMemberRepository.save(groupMember);
+            log.info("그룹-멤버 생성");
+
+        } catch (Exception e){
+            throw new CommonException(ResponseCode.BAD_REQUEST, e);
+        }
+    }
+
+}

--- a/src/main/java/com/grepp/spring/app/model/group/service/GroupService.java
+++ b/src/main/java/com/grepp/spring/app/model/group/service/GroupService.java
@@ -10,8 +10,6 @@ import com.grepp.spring.app.model.group.repository.GroupMemberRepository;
 import com.grepp.spring.app.model.group.repository.GroupRepository;
 import com.grepp.spring.app.model.member.entity.Member;
 import com.grepp.spring.app.model.member.repository.MemberRepository;
-import com.grepp.spring.infra.error.exceptions.CommonException;
-import com.grepp.spring.infra.response.ResponseCode;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -39,6 +37,7 @@ public class GroupService {
         Member member = memberRepository.findById(user.getUsername()).orElseThrow();
         log.info("멤버 조회");
         List<GroupMember> groupMember = groupMemberRepository.findByMemberId(member.getId());
+        System.out.println(groupMember);
         for (GroupMember groupMember1: groupMember){
 
             System.out.println(groupMember1.getGroup().getId());
@@ -48,28 +47,23 @@ public class GroupService {
     // 그룹 생성
     @Transactional
     public void registGroup(CreateGroupRequest request){
-        try{
 
-            // 그룹 생성
-            GroupCreateDto groupCreateDto = GroupCreateDto.toDto(request);
-            Group group = GroupCreateDto.toEntity(groupCreateDto);
-            groupRepository.save(group);
-            log.info("그룹생성");
+        // 그룹 생성
+        GroupCreateDto groupCreateDto = GroupCreateDto.toDto(request);
+        Group group = GroupCreateDto.toEntity(groupCreateDto);
+        groupRepository.save(group);
+        log.info("그룹생성");
 
-            // http 요청 사용자 조회
-            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-            Principal user = (Principal) authentication.getPrincipal();
-            Member member = memberRepository.findById(user.getUsername()).orElseThrow();
-            log.info("멤버 조회");
+        // http 요청 사용자 조회
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Principal user = (Principal) authentication.getPrincipal();
+        Member member = memberRepository.findById(user.getUsername()).orElseThrow();
+        log.info("멤버 조회");
 
-            // 그룹-멤버 생성 (중간 테이블)
-            GroupMember groupMember = GroupMemberCreateDto.toEntity(group, member);
-            groupMemberRepository.save(groupMember);
-            log.info("그룹-멤버 생성");
-
-        } catch (Exception e){
-            throw new CommonException(ResponseCode.BAD_REQUEST, e);
+        // 그룹-멤버 생성 (중간 테이블)
+        GroupMember groupMember = GroupMemberCreateDto.toEntity(group, member);
+        groupMemberRepository.save(groupMember);
+        log.info("그룹-멤버 생성");
         }
-    }
 
 }


### PR DESCRIPTION
이벤트 생성 기능 구현

## ✅ 관련 이슈
- close #12

## 🛠️ 작업 내용
- 이벤트 생성 기능
  - 후보 시간대 생성 기능
  - 이벤트 생성 시 이벤트-그룹에 방장 권한을 부여한 인원 추가
  - 그룹 이벤트의 경우 그룹 검증, 그룹원 여부 검증

## 📸 스크린샷
- API 요청 예시
<img width="328" height="272" alt="image" src="https://github.com/user-attachments/assets/b4ba3dc7-6ca3-42eb-82a0-8bb1767092ab" />

- events 테이블 (일부)
<img width="612" height="39" alt="image" src="https://github.com/user-attachments/assets/9a94bb81-e99c-4ffd-8e60-ea25b3efc95a" />

- event_members 테이블 (일부)
<img width="308" height="38" alt="image" src="https://github.com/user-attachments/assets/1fe7139a-e9f3-457c-ab8c-e050d34a7cf2" />

- candidate_dates 테이블 (일부)
<img width="412" height="77" alt="image" src="https://github.com/user-attachments/assets/ebf13055-1181-4e77-8425-b2a568f71937" />

## 🧩 기타 참고사항
EventService의 createMasterMember 메소드로 이벤트 멤버를 추가할 때 로직이 이벤트 참여에서 멤버 추가하는 로직과 동일할 것으로 예상되어 수정될 예정입니다.
