### PR TITLE
🐛 fix: GroupMember 엔티티 수정

### DIFF
--- a/src/main/java/com/grepp/spring/app/model/group/dto/GroupMemberCreateDto.java
+++ b/src/main/java/com/grepp/spring/app/model/group/dto/GroupMemberCreateDto.java
@@ -11,6 +11,7 @@ public class GroupMemberCreateDto {
         GroupMember groupMember = new GroupMember();
         groupMember.setGroup(group);
         groupMember.setMember(member);
+        groupMember.setGroupAdmin(true);
         groupMember.setRole(GroupRole.GROUP_LEADER);
 
         return groupMember;

--- a/src/main/java/com/grepp/spring/app/model/group/entity/GroupMember.java
+++ b/src/main/java/com/grepp/spring/app/model/group/entity/GroupMember.java
@@ -5,6 +5,8 @@ import com.grepp.spring.app.model.member.entity.Member;
 import com.grepp.spring.infra.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -38,6 +40,7 @@ public class GroupMember extends BaseEntity {
     private Long id;
 
     @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
     private GroupRole role;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -48,4 +51,5 @@ public class GroupMember extends BaseEntity {
     @JoinColumn(name = "group_id")
     private Group group;
 
+    private Boolean groupAdmin;
 }

--- a/src/main/java/com/grepp/spring/app/model/group/service/GroupService.java
+++ b/src/main/java/com/grepp/spring/app/model/group/service/GroupService.java
@@ -64,6 +64,6 @@ public class GroupService {
         GroupMember groupMember = GroupMemberCreateDto.toEntity(group, member);
         groupMemberRepository.save(groupMember);
         log.info("그룹-멤버 생성");
-        }
+    }
 
 }


### PR DESCRIPTION
!! Aggignees , Label 붙여주세요!! <br>
!! Add a title 작성 규칙 :  -- 했습니다. -- 입니다. (X) 로그인 기능 구현했습니다. (x)  ->  로그인 기능 구현 완료 (O)

## ✅ 관련 이슈
- close #20

## 🛠️ 작업 내용
GroupMember의 Role이 Varchar로 저장되도록 수정
GroupMember에 그룹슈퍼방장 확인 필드 추가(groupAdmin)

## 📸 스크린샷 (선택)
<img width="1465" height="124" alt="image" src="https://github.com/user-attachments/assets/b85c357a-de52-442b-a509-aacb7bb1fcf6" />
groupAdmin이 true인 경우 그룹 슈퍼 방장입니다.

## 🧩 기타 참고사항
- GroupMember 엔티티의 필드가 변경되었습니다. merge나 rebase 이후 create로 데이터베이스를 한 번 갈아엎어주세요.
