### PR TITLE
✨ feat: 사용자 정보 조회 및 로그아웃 기능 구현

### DIFF
--- a/src/main/java/com/grepp/spring/app/controller/api/auth/AuthController.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/auth/AuthController.java
@@ -17,13 +17,16 @@ import com.grepp.spring.infra.auth.jwt.TokenCookieFactory;
 import com.grepp.spring.infra.response.ApiResponse;
 import com.grepp.spring.infra.response.ResponseCode;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -92,7 +95,19 @@ public class AuthController {
 
     @Operation(summary = "로그아웃", description = "로그아웃을 진행합니다.")
     @PostMapping("/logout")
-    public ResponseEntity<ApiResponse<?>> logout() {
+    public ResponseEntity<ApiResponse<?>> logout(HttpServletResponse response) {
+
+        ResponseCookie deleteAccessTokenCookie = TokenCookieFactory.createExpiredToken(AuthToken.ACCESS_TOKEN.name());
+        response.addHeader(HttpHeaders.SET_COOKIE, deleteAccessTokenCookie.toString());
+
+        ResponseCookie deleteRefreshTokenCookie = TokenCookieFactory.createExpiredToken(AuthToken.REFRESH_TOKEN.name());
+        response.addHeader(HttpHeaders.SET_COOKIE, deleteRefreshTokenCookie.toString());
+
+        ResponseCookie deleteSessionIdCookie = TokenCookieFactory.createExpiredToken(AuthToken.AUTH_SERVER_SESSION_ID.name());
+        response.addHeader(HttpHeaders.SET_COOKIE, deleteSessionIdCookie.toString());
+
+        SecurityContextHolder.clearContext();
+
         return ResponseEntity.ok(ApiResponse.noContent());
     }
 

--- a/src/main/java/com/grepp/spring/app/controller/api/member/MemberController.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/member/MemberController.java
@@ -1,0 +1,56 @@
+package com.grepp.spring.app.controller.api.member;
+
+import com.grepp.spring.app.controller.api.member.payload.MemberInfoResponse;
+import com.grepp.spring.app.model.member.entity.Member;
+import com.grepp.spring.app.model.member.service.MemberService;
+import com.grepp.spring.infra.response.ApiResponse;
+import com.grepp.spring.infra.response.ResponseCode;
+import io.swagger.v3.oas.annotations.Operation;
+import java.util.NoSuchElementException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/member")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @Operation(summary = "사용자 정보 조회", description = "현재 로그인 중인 사용자의 정보를 가져올 수 있습니다.")
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<MemberInfoResponse>> getMemberInfo(Authentication authentication) {
+
+        try {
+            UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+            String username = userDetails.getUsername();
+
+            Member member = memberService.findById(username).orElseThrow();
+
+            MemberInfoResponse response = new MemberInfoResponse();
+            response.setId(member.getId());
+            response.setName(member.getName());
+            response.setEmail(member.getEmail());
+            response.setRole(member.getRole().name());
+            response.setProfileImageNumber(member.getProfileImageNumber());
+            response.setProvider(member.getProvider().name());
+
+            return ResponseEntity.ok(ApiResponse.success(response));
+            // 데이터베이스에 등록되지 않은 사용자인 경우
+        } catch (NoSuchElementException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ApiResponse.error(ResponseCode.NOT_FOUND,"유저를 찾을 수 없습니다."));
+            // 그 외 예상치 못한 예외 처리
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.error(ResponseCode.INTERNAL_SERVER_ERROR, ResponseCode.INTERNAL_SERVER_ERROR.message()));
+        }
+        // 위 예외들은 추후 GlobalAdvice로 처리하는 방법을 생각중입니다.
+    }
+}

--- a/src/main/java/com/grepp/spring/app/controller/api/member/payload/MemberInfoResponse.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/member/payload/MemberInfoResponse.java
@@ -1,0 +1,17 @@
+package com.grepp.spring.app.controller.api.member.payload;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class MemberInfoResponse {
+
+    private String id;
+    private String email;
+    private String name;
+    private Long profileImageNumber;
+    private String provider;
+    private String role;
+
+}

--- a/src/main/java/com/grepp/spring/app/model/member/repository/MemberRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/member/repository/MemberRepository.java
@@ -1,7 +1,6 @@
 package com.grepp.spring.app.model.member.repository;
 
 import com.grepp.spring.app.model.member.entity.Member;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 
@@ -12,7 +11,5 @@ public interface MemberRepository extends JpaRepository<Member, String> {
     boolean existsByEmailIgnoreCase(String email);
 
     boolean existsByTelIgnoreCase(String tel);
-
-    Optional<Member> findById(String id);
 
 }

--- a/src/main/java/com/grepp/spring/app/model/member/service/MemberService.java
+++ b/src/main/java/com/grepp/spring/app/model/member/service/MemberService.java
@@ -1,0 +1,19 @@
+package com.grepp.spring.app.model.member.service;
+
+import com.grepp.spring.app.model.member.entity.Member;
+import com.grepp.spring.app.model.member.repository.MemberRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public Optional<Member> findById(String userId) {
+        return memberRepository.findById(userId);
+    }
+
+}


### PR DESCRIPTION
## ✅ 관련 이슈
- close #28 

## 🛠️ 작업 내용
- 로그인한 사용자의 정보를 조회할 수 있는 API를 추가했습니다.
- 로그아웃 API를 추가했습니다. 호출 시 세션에 있는 모든 토큰이 삭제됩니다.
- MemberRepository에 있는 findById 메서드를 삭제했습니다.
  기존에 findById 메서드를 이용하셨다면, JpaRepository가 생성해주는 메서드로 대체됩니다. 기능은 동일합니다.

## 📸 스크린샷
- 로그인(임시 로그인 API or Oauth2 소셜 로그인 택 1) 후 권한이 생기면 사용자 정보를 조회할 수 있습니다.
<img width="1422" height="907" alt="스크린샷 2025-07-12 022310" src="https://github.com/user-attachments/assets/5ce7fe97-9ec0-4028-b0f8-7247b83f7c8c" />
- 보시는 것처럼 로그아웃 API를 호출하면 세션의 토큰이 날아갑니다.
<img width="1428" height="789" alt="스크린샷 2025-07-12 022215" src="https://github.com/user-attachments/assets/f84b6913-c33b-461f-afff-63e98242207b" />
