### PR TITLE
✨ feat: 이벤트 개인 시간대 입력/수정 기능 구현

### DIFF
--- a/src/main/java/com/grepp/spring/app/controller/api/event/EventController.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/event/EventController.java
@@ -99,8 +99,7 @@ public class EventController {
         try {
             String currentMemberId = extractCurrentMemberId();
 
-            MyTimeScheduleDto dto = MyTimeScheduleDto.toDto(request, eventId, currentMemberId);
-            eventService.createOrUpdateMyTime(dto);
+            eventService.createOrUpdateMyTime(request, eventId, currentMemberId);
 
             return ResponseEntity.ok(ApiResponse.success("개인 일정이 성공적으로 생성/수정되었습니다."));
 

--- a/src/main/java/com/grepp/spring/app/controller/api/event/payload/request/MyTimeScheduleRequest.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/event/payload/request/MyTimeScheduleRequest.java
@@ -1,29 +1,36 @@
 package com.grepp.spring.app.controller.api.event.payload.request;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.Setter;
 
-import java.util.List;
-
 import java.time.LocalDate;
+import java.util.List;
 
 @Getter
 @Setter
 public class MyTimeScheduleRequest {
 
-    @NotNull
+    @NotNull(message = "dailyTimeSlots는 필수입니다")
+    @NotEmpty(message = "최소 1개의 시간 슬롯이 필요합니다")
+    @Valid
     private List<DailyTimeSlot> dailyTimeSlots;
-    @NotNull
+
+    @NotNull(message = "timezone은 필수입니다")
+    @Pattern(regexp = "^[A-Za-z]+/[A-Za-z_]+$|^UTC[+-]\\d{1,2}$|^[A-Z]{3,4}$",
+        message = "올바른 timezone 형식이어야 합니다 (예: Asia/Seoul, UTC+9)")
     private String timezone;
 
     @Getter
     @Setter
     public static class DailyTimeSlot {
-        @NotNull
+        @NotNull(message = "날짜는 필수입니다")
         private LocalDate date;
 
-        @NotNull
-        private String timeBit; // 비트로 30분 단위 시간 표현 (0~47: 00:00~23:30)
+        @NotNull(message = "timeBit은 필수입니다")
+        private String timeBit;
     }
 }

--- a/src/main/java/com/grepp/spring/app/model/event/dto/MyTimeScheduleDto.java
+++ b/src/main/java/com/grepp/spring/app/model/event/dto/MyTimeScheduleDto.java
@@ -1,0 +1,61 @@
+package com.grepp.spring.app.model.event.dto;
+
+import com.grepp.spring.app.controller.api.event.payload.request.MyTimeScheduleRequest;
+import com.grepp.spring.app.model.event.entity.EventMember;
+import com.grepp.spring.app.model.event.entity.TempSchedule;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+public class MyTimeScheduleDto {
+    private final Long eventId;
+    private final String memberId;
+    private final String timezone;
+    private final List<DailyTimeSlotDto> dailyTimeSlots;
+
+    @Getter
+    @Builder
+    public static class DailyTimeSlotDto {
+        private final LocalDate date;
+        private final String timeBit; // 16진수 12자리
+
+        public Long getTimeBitAsLong() {
+            return Long.parseUnsignedLong(this.timeBit, 16);
+        }
+
+        public static TempSchedule toEntity(DailyTimeSlotDto dto, EventMember eventMember) {
+            TempSchedule tempSchedule = new TempSchedule();
+            tempSchedule.setEventMember(eventMember);
+            tempSchedule.setDate(dto.getDate());
+            tempSchedule.setTimeBit(dto.getTimeBitAsLong());
+            return tempSchedule;
+        }
+    }
+
+    public static MyTimeScheduleDto toDto(MyTimeScheduleRequest request, Long eventId, String memberId) {
+        List<DailyTimeSlotDto> dailyTimeSlots = request.getDailyTimeSlots().stream()
+            .map(slot -> DailyTimeSlotDto.builder()
+                .date(slot.getDate())
+                .timeBit(slot.getTimeBit().toUpperCase())
+                .build())
+            .collect(Collectors.toList());
+
+        return MyTimeScheduleDto.builder()
+            .eventId(eventId)
+            .memberId(memberId)
+            .timezone(request.getTimezone())
+            .dailyTimeSlots(dailyTimeSlots)
+            .build();
+    }
+
+    public static List<TempSchedule> toEntityList(MyTimeScheduleDto dto, EventMember eventMember) {
+        return dto.getDailyTimeSlots().stream()
+            .map(slot -> DailyTimeSlotDto.toEntity(slot, eventMember))
+            .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/grepp/spring/app/model/event/entity/TempSchedule.java
+++ b/src/main/java/com/grepp/spring/app/model/event/entity/TempSchedule.java
@@ -5,7 +5,7 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 
 @Entity
@@ -20,7 +20,7 @@ public class TempSchedule extends BaseEntity {
     private Long id;
 
     @Column(nullable = false)
-    private LocalDateTime date;
+    private LocalDate date;
 
     @Column(nullable = false)
     private Long timeBit;

--- a/src/main/java/com/grepp/spring/app/model/event/repository/EventMemberRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/event/repository/EventMemberRepository.java
@@ -3,9 +3,14 @@ package com.grepp.spring.app.model.event.repository;
 import com.grepp.spring.app.model.event.entity.EventMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface EventMemberRepository extends JpaRepository<EventMember, Long> {
 
     Long countByEventId(Long eventId);
+
     Boolean existsByEventIdAndMemberId(Long eventId, String memberId);
+
+    Optional<EventMember> findByEventIdAndMemberIdAndActivatedTrue(Long eventId, String memberId);
 
 }

--- a/src/main/java/com/grepp/spring/app/model/event/repository/TempScheduleRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/event/repository/TempScheduleRepository.java
@@ -1,0 +1,13 @@
+package com.grepp.spring.app.model.event.repository;
+
+import com.grepp.spring.app.model.event.entity.TempSchedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+public interface TempScheduleRepository extends JpaRepository<TempSchedule, Long> {
+
+    Optional<TempSchedule> findByEventMemberIdAndDateAndActivatedTrue(Long eventMemberId, LocalDate date);
+
+}

--- a/src/main/java/com/grepp/spring/app/model/event/service/EventService.java
+++ b/src/main/java/com/grepp/spring/app/model/event/service/EventService.java
@@ -1,6 +1,7 @@
 package com.grepp.spring.app.model.event.service;
 
 import com.grepp.spring.app.controller.api.event.payload.request.CreateEventRequest;
+import com.grepp.spring.app.controller.api.event.payload.request.MyTimeScheduleRequest;
 import com.grepp.spring.app.model.event.code.Role;
 import com.grepp.spring.app.model.event.dto.*;
 import com.grepp.spring.app.model.event.entity.CandidateDate;
@@ -144,7 +145,9 @@ public class EventService {
     }
 
     @Transactional
-    public void createOrUpdateMyTime(MyTimeScheduleDto dto) {
+    public void createOrUpdateMyTime(MyTimeScheduleRequest request, Long eventId, String currentMemberId) {
+        MyTimeScheduleDto dto = MyTimeScheduleDto.toDto(request, eventId, currentMemberId);
+
         Event event = eventRepository.findById(dto.getEventId())
             .orElseThrow(() -> new NotFoundException("존재하지 않는 이벤트입니다. ID: " + dto.getEventId()));
 

--- a/src/main/java/com/grepp/spring/app/model/event/service/EventService.java
+++ b/src/main/java/com/grepp/spring/app/model/event/service/EventService.java
@@ -2,14 +2,15 @@ package com.grepp.spring.app.model.event.service;
 
 import com.grepp.spring.app.controller.api.event.payload.request.CreateEventRequest;
 import com.grepp.spring.app.model.event.code.Role;
-import com.grepp.spring.app.model.event.dto.CandidateDateDto;
-import com.grepp.spring.app.model.event.dto.CreateEventDto;
-import com.grepp.spring.app.model.event.dto.EventMemberDto;
-import com.grepp.spring.app.model.event.dto.JoinEventDto;
+import com.grepp.spring.app.model.event.dto.*;
 import com.grepp.spring.app.model.event.entity.CandidateDate;
 import com.grepp.spring.app.model.event.entity.Event;
 import com.grepp.spring.app.model.event.entity.EventMember;
-import com.grepp.spring.app.model.event.repository.*;
+import com.grepp.spring.app.model.event.entity.TempSchedule;
+import com.grepp.spring.app.model.event.repository.CandidateDateRepository;
+import com.grepp.spring.app.model.event.repository.EventMemberRepository;
+import com.grepp.spring.app.model.event.repository.EventRepository;
+import com.grepp.spring.app.model.event.repository.TempScheduleRepository;
 import com.grepp.spring.app.model.group.entity.Group;
 import com.grepp.spring.app.model.group.entity.GroupMember;
 import com.grepp.spring.app.model.group.repository.GroupMemberRepository;
@@ -22,7 +23,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -36,6 +39,7 @@ public class EventService {
     private final MemberRepository memberRepository;
     private final GroupRepository groupRepository;
     private final GroupMemberRepository groupMemberRepository;
+    private final TempScheduleRepository tempScheduleRepository;
 
     @Transactional
     public void createEvent(CreateEventRequest webRequest, String currentMemberId) {
@@ -137,6 +141,38 @@ public class EventService {
 
         EventMember eventMember = EventMemberDto.toEntity(dto, event, member);
         eventMemberRepository.save(eventMember);
+    }
+
+    @Transactional
+    public void createOrUpdateMyTime(MyTimeScheduleDto dto) {
+        Event event = eventRepository.findById(dto.getEventId())
+            .orElseThrow(() -> new NotFoundException("존재하지 않는 이벤트입니다. ID: " + dto.getEventId()));
+
+        EventMember eventMember = eventMemberRepository.findByEventIdAndMemberIdAndActivatedTrue(dto.getEventId(), dto.getMemberId())
+            .orElseThrow(() -> new NotFoundException("이벤트에 참여하지 않은 회원입니다."));
+
+        for (MyTimeScheduleDto.DailyTimeSlotDto slot : dto.getDailyTimeSlots()) {
+            updateOrCreateTempSchedule(eventMember, slot);
+        }
+    }
+
+    private void updateOrCreateTempSchedule(EventMember eventMember, MyTimeScheduleDto.DailyTimeSlotDto slot) {
+        LocalDate date = slot.getDate();
+
+        Optional<TempSchedule> existingSchedule = tempScheduleRepository
+            .findByEventMemberIdAndDateAndActivatedTrue(eventMember.getId(), date);
+
+        if (existingSchedule.isPresent()) {
+            TempSchedule schedule = existingSchedule.get();
+            Long currentTimeBit = schedule.getTimeBit();
+            Long newTimeBit = currentTimeBit ^ slot.getTimeBitAsLong();
+
+            schedule.setTimeBit(newTimeBit);
+            tempScheduleRepository.save(schedule);
+        } else {
+            TempSchedule newSchedule = MyTimeScheduleDto.DailyTimeSlotDto.toEntity(slot, eventMember);
+            tempScheduleRepository.save(newSchedule);
+        }
     }
 
 }


### PR DESCRIPTION
## ✅ 관련 이슈
- close #27

## 🛠️ 작업 내용
- 이벤트 개인 시간대 입력/수정 기능
  - 개인 시간대를 16진수로 입력받아 저장
  - 개인 시간대가 변경될 시 XOR 연산으로 기존 DB에 저장된 timebit 수정

## 📸 스크린샷
- API 요청 예시
<img width="613" height="449" alt="image" src="https://github.com/user-attachments/assets/afae4261-f8e2-49ff-8a4c-ad8be722e202" />

- API 요청에 사용된 비트 값
<img width="613" height="348" alt="image" src="https://github.com/user-attachments/assets/ee83edd3-b745-4939-a42f-e349304a1f23" />


- [입력] temp_schedules 테이블 (일부)
<img width="468" height="80" alt="image" src="https://github.com/user-attachments/assets/1512737f-dd59-4df1-a306-78666f964702" />

- [수정 후] temp_schedules 테이블 (일부)
<img width="469" height="82" alt="image" src="https://github.com/user-attachments/assets/e24f8a6c-0d7f-4133-93c5-2541d9af69b1" />


## 🧩 기타 참고사항
- TempSchedule의 날짜를 LocalDateTime -> LocalDate로 수정했습니다. DB 업데이트 부탁드립니다.
- TimeZone을 고려하여 저장하는 기능은 다음 회의에서 상세한 논의가 필요합니다.
  - 날짜만 timezone을 고려하고 TimeBit는 그대로 유지하는 방안
  - Timezone 정보를 고려하여 TimeBit를 한국 시간대로 저장하는 방안