### PR TITLE
✨ feat: 즐겨찾기 장소 및 시간대 조회 + 시간대 중복 등록 방지

### DIFF
--- a/src/main/java/com/grepp/spring/app/controller/api/mypage/MypageController.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/mypage/MypageController.java
@@ -31,6 +31,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -75,7 +76,7 @@ public class MypageController {
           .body(ApiResponse.error(ResponseCode.CONFLICT_REGISTER, "이미 즐겨찾기 장소를 등록했습니다."));
 
     } catch (Exception e) {
-      if (e instanceof AuthApiException) {
+      if (e instanceof AuthenticationException) {
         return ResponseEntity.status(401)
             .body(ApiResponse.error(ResponseCode.UNAUTHORIZED, "권한이 없습니다."));
       }
@@ -110,6 +111,66 @@ public class MypageController {
       return ResponseEntity.ok(ApiResponse.success(response));
 
       
+    } catch (IllegalStateException e) {
+      return ResponseEntity.status(409)
+          .body(ApiResponse.error(ResponseCode.CONFLICT_REGISTER, "해당 시간대는 기존에 등록된 즐겨찾기 시간대와 겹칩니다."));
+
+    } catch (Exception e) {
+      if (e instanceof AuthApiException) {
+        return ResponseEntity.status(401)
+            .body(ApiResponse.error(ResponseCode.UNAUTHORIZED, "권한이 없습니다."));
+      }
+      return ResponseEntity.status(400)
+          .body(ApiResponse.error(ResponseCode.BAD_REQUEST, "서버가 요청을 처리할 수 없습니다."));
+    }
+  }
+
+  @GetMapping("/favorite-locations")
+  @Operation(summary = "즐겨찾기 장소 조회", description = "회원 즐겨찾기 장소 조회")
+  public ResponseEntity<ApiResponse<List<FavoriteLocationDto>>> getFavoriteLocations() {
+    try {
+
+      Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+      if (authentication == null) {
+        throw new IllegalStateException("로그인된 사용자 정보를 확인할 수 없습니다.");
+      }
+
+      String memberId = authentication.getName();
+      List<FavoriteLocationDto> result = mypageService.getFavoriteLocations(memberId);
+
+      // API 응답 감싸서 반환
+      return ResponseEntity.ok(ApiResponse.success(result));
+
+
+    } catch (Exception e) {
+      if (e instanceof AuthApiException) {
+        return ResponseEntity.status(401)
+            .body(ApiResponse.error(ResponseCode.UNAUTHORIZED, "권한이 없습니다."));
+      }
+      return ResponseEntity.status(400)
+          .body(ApiResponse.error(ResponseCode.BAD_REQUEST, "서버가 요청을 처리할 수 없습니다."));
+    }
+  }
+
+  @GetMapping("/favorite-timetable")
+  @Operation(summary = "즐겨찾기 시간대 조회", description = "회원 즐겨찾기 시간대 조회")
+  public ResponseEntity<ApiResponse<List<FavoriteTimetableDto>>> getFavoriteTimetables() {
+    try {
+
+      Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+      if (authentication == null) {
+        throw new IllegalStateException("로그인된 사용자 정보를 확인할 수 없습니다.");
+      }
+
+      String memberId = authentication.getName();
+      List<FavoriteTimetableDto> result = mypageService.getFavoriteTimetables(memberId);
+
+      // API 응답 감싸서 반환
+      return ResponseEntity.ok(ApiResponse.success(result));
+
+
     } catch (Exception e) {
       if (e instanceof AuthApiException) {
         return ResponseEntity.status(401)

--- a/src/main/java/com/grepp/spring/app/controller/api/mypage/payload/request/CreateFavoritePlaceRequest.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/mypage/payload/request/CreateFavoritePlaceRequest.java
@@ -1,6 +1,7 @@
 package com.grepp.spring.app.controller.api.mypage.payload.request;
 
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
@@ -9,10 +10,13 @@ import lombok.Setter;
 @Setter
 
 public class CreateFavoritePlaceRequest {
+    @Schema(example = "강남역 2번 출구")
     @NotNull
     private String stationName; // 역이름으로 수정
+    @Schema(example = "37.4979")
     @NotNull
     private double latitude;
+    @Schema(example = "127.0276")
     @NotNull
     private double longitude;
 

--- a/src/main/java/com/grepp/spring/app/controller/api/mypage/payload/request/CreateFavoriteTimeRequest.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/mypage/payload/request/CreateFavoriteTimeRequest.java
@@ -1,5 +1,6 @@
 package com.grepp.spring.app.controller.api.mypage.payload.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import java.time.DayOfWeek;
 import java.time.LocalDateTime;
@@ -10,10 +11,14 @@ import lombok.Setter;
 @Getter
 @Setter
 public class CreateFavoriteTimeRequest {
+
+    @Schema(example = "14:00")
     @NotNull
     private LocalTime startTime;
+    @Schema(example = "15:00")
     @NotNull
     private LocalTime endTime;
+    @Schema(example = "MONDAY")
     @NotNull
     private DayOfWeek weekday;
 

--- a/src/main/java/com/grepp/spring/app/model/mypage/repository/MyLocationRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/mypage/repository/MyLocationRepository.java
@@ -1,6 +1,7 @@
 package com.grepp.spring.app.model.mypage.repository;
 
 import com.grepp.spring.app.model.mypage.entity.FavoriteLocation;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,4 +11,6 @@ public interface MyLocationRepository extends JpaRepository<FavoriteLocation, Lo
 
   // 즐찾 장소 존재 여부 확인
   boolean existsByMemberId(String memberId);
+
+  List<FavoriteLocation> findAllByMemberId(String memberId);
 }

--- a/src/main/java/com/grepp/spring/app/model/mypage/repository/MyTimetableRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/mypage/repository/MyTimetableRepository.java
@@ -1,10 +1,34 @@
 package com.grepp.spring.app.model.mypage.repository;
 
 import com.grepp.spring.app.model.mypage.entity.FavoriteTimetable;
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MyTimetableRepository extends JpaRepository<FavoriteTimetable, Long> {
+
+  List<FavoriteTimetable> findAllByMemberId(String memberId);
+
+
+
+  @Query("""
+      SELECT CASE WHEN COUNT(ft) > 0 THEN true ELSE false END
+      FROM FavoriteTimetable ft
+      WHERE ft.member.id = :memberId
+        AND ft.weekday = :weekday
+        AND ft.startTime < :endTime
+        AND ft.endTime > :startTime
+  """)
+  boolean existsOverlappingTime(
+      @Param("memberId") String memberId,
+      @Param("weekday") DayOfWeek weekday,
+      @Param("startTime") LocalTime startTime,
+      @Param("endTime") LocalTime endTime
+  );
 
 }


### PR DESCRIPTION
## ✅ 관련 이슈
- close #18 

## 🛠️ 작업 내용

- 즐겨찾기 장소 및 시간대 조회 기능 구현
#### <수정사항>
- 기존 즐겨찾기 시간대 등록 시, 똑같은 시간대나 겹치는 시간대가 중복 등록되는 경우 발생 , 해당 부분 예외 처리
 : 겹침 기준 ->  '동일 요일' 에서 startTime < 기존 endTime && endTime > 기존 startTime
- swagger 요청 예시 개선 : CreateFavoriteTimeRequest, CreateFavoritePlaceRequest 에 @ Schema(example) 적용

## 📸 스크린샷 (선택)

<img width="1196" height="720" alt="image" src="https://github.com/user-attachments/assets/3aa6df75-00bc-4d69-b656-3f2afead9478" />

<img width="1138" height="785" alt="image" src="https://github.com/user-attachments/assets/b67bcec1-3ef6-4b71-80b4-6db9d38dadb8" />

### 중복된 / 겹치는 시간대 등록 요청 했을 때
<img width="1158" height="353" alt="image" src="https://github.com/user-attachments/assets/c19983bc-de32-4489-9c8b-dfb596ed535e" />


## 🧩 기타 참고사항
`즐겨찾기 장소 및 시간대 수정 기능`은 다음 PR에서 작업 예정입니다.
