### PR TITLE
✨ feat: 참여자 전원의 가능한 시간대 조회 기능 구현

### DIFF
--- a/src/main/java/com/grepp/spring/app/controller/api/event/EventController.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/event/EventController.java
@@ -134,8 +134,7 @@ public class EventController {
                     .body(ApiResponse.error(ResponseCode.UNAUTHORIZED, "로그인이 필요합니다."));
             }
 
-            AllTimeScheduleDto dto = eventService.getAllTimeSchedules(eventId, currentMemberId);
-            AllTimeScheduleResponse response = AllTimeScheduleDto.fromDto(dto);
+            AllTimeScheduleResponse response = eventService.getAllTimeSchedules(eventId, currentMemberId);
 
             return ResponseEntity.ok(ApiResponse.success(response));
 

--- a/src/main/java/com/grepp/spring/app/controller/api/event/EventController.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/event/EventController.java
@@ -103,10 +103,6 @@ public class EventController {
 
             return ResponseEntity.ok(ApiResponse.success("개인 일정이 성공적으로 생성/수정되었습니다."));
 
-        } catch (AuthApiException e) {
-            return ResponseEntity.status(401)
-                .body(ApiResponse.error(ResponseCode.UNAUTHORIZED, e.getMessage()));
-
         } catch (NotFoundException e) {
             return ResponseEntity.status(404)
                 .body(ApiResponse.error(ResponseCode.NOT_FOUND, e.getMessage()));
@@ -128,11 +124,6 @@ public class EventController {
 
         try {
             String currentMemberId = extractCurrentMemberId();
-
-            if (currentMemberId == null) {
-                return ResponseEntity.status(401)
-                    .body(ApiResponse.error(ResponseCode.UNAUTHORIZED, "로그인이 필요합니다."));
-            }
 
             AllTimeScheduleResponse response = eventService.getAllTimeSchedules(eventId, currentMemberId);
 

--- a/src/main/java/com/grepp/spring/app/controller/api/event/EventController.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/event/EventController.java
@@ -4,6 +4,7 @@ import com.grepp.spring.app.controller.api.event.payload.request.CreateEventRequ
 import com.grepp.spring.app.controller.api.event.payload.request.CreateScheduleResultRequest;
 import com.grepp.spring.app.controller.api.event.payload.request.MyTimeScheduleRequest;
 import com.grepp.spring.app.controller.api.event.payload.response.*;
+import com.grepp.spring.app.model.event.dto.AllTimeScheduleDto;
 import com.grepp.spring.app.model.event.dto.MyTimeScheduleDto;
 import com.grepp.spring.app.model.event.service.EventService;
 import com.grepp.spring.infra.error.exceptions.AuthApiException;
@@ -21,7 +22,6 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import javax.security.sasl.AuthenticationException;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -127,119 +127,29 @@ public class EventController {
     public ResponseEntity<ApiResponse<AllTimeScheduleResponse>> getAllTimeSchedules(@PathVariable Long eventId) {
 
         try {
-            if (
-                eventId != 20000 && eventId != 20001 && eventId != 20002 &&
-                    eventId != 20003 && eventId != 20004 && eventId != 20005
-            ) {
-                return ResponseEntity.status(404)
-                    .body(ApiResponse.error(ResponseCode.NOT_FOUND, "해당 이벤트를 찾을 수 없습니다."));
+            String currentMemberId = extractCurrentMemberId();
+
+            if (currentMemberId == null) {
+                return ResponseEntity.status(401)
+                    .body(ApiResponse.error(ResponseCode.UNAUTHORIZED, "로그인이 필요합니다."));
             }
 
-            AllTimeScheduleResponse response = new AllTimeScheduleResponse();
-            response.setEventId(eventId);
-            response.setEventTitle("시이바 카츠오모이");
-            response.setTotalMembers(3);
-            response.setConfirmedMembers(2);
-
-            AllTimeScheduleResponse.TimeTable timeTable = new AllTimeScheduleResponse.TimeTable();
-            List<String> dates = new ArrayList<>();
-            dates.add("2025-07-13");
-            dates.add("2025-07-14");
-            dates.add("2025-07-15");
-            dates.add("2025-07-16");
-            dates.add("2025-07-17");
-            dates.add("2025-07-18");
-            dates.add("2025-07-19");
-            timeTable.setDates(dates);
-            timeTable.setStartTime("09:30");
-            timeTable.setEndTime("12:30");
-            response.setTimeTable(timeTable);
-
-            // 멤버별 스케줄 정보
-            List<AllTimeScheduleResponse.MemberSchedule> memberSchedules = new ArrayList<>();
-
-            // 첫 번째 멤버 (나의 가능한 시간)
-            AllTimeScheduleResponse.MemberSchedule member1 = new AllTimeScheduleResponse.MemberSchedule();
-            member1.setEventMemberId("google_1234");
-            member1.setMemberName("나의 가능한 시간");
-            member1.setRole("HOST");
-            member1.setIsConfirmed(true);
-
-            List<AllTimeScheduleResponse.DailyTimeSlot> member1Slots = new ArrayList<>();
-            for (int i = 13; i <= 19; i++) {
-                AllTimeScheduleResponse.DailyTimeSlot slot = new AllTimeScheduleResponse.DailyTimeSlot();
-                LocalDate date = LocalDate.of(2025, 7, i);
-                slot.setDate(date);
-                slot.setDayOfWeek(date.getDayOfWeek().toString().substring(0, 3).toUpperCase());
-                slot.setDisplayDate(String.format("07/%02d", i));
-
-                // Mock 데이터: 10-12시 시간대에 가능 (비트 20~23: 10:00, 10:30, 11:00, 11:30)
-                slot.setTimeBit("0000"); // 20~23번째 비트
-                member1Slots.add(slot);
-            }
-            member1.setDailyTimeSlots(member1Slots);
-
-            // 두 번째 멤버 (모두 가능한 시간)
-            AllTimeScheduleResponse.MemberSchedule member2 = new AllTimeScheduleResponse.MemberSchedule();
-            member2.setEventMemberId("google_4567");
-            member2.setMemberName("모두 가능한 시간");
-            member2.setRole("MEMBER");
-            member2.setIsConfirmed(true);
-
-            List<AllTimeScheduleResponse.DailyTimeSlot> member2Slots = new ArrayList<>();
-            for (int i = 13; i <= 19; i++) {
-                AllTimeScheduleResponse.DailyTimeSlot slot = new AllTimeScheduleResponse.DailyTimeSlot();
-                LocalDate date = LocalDate.of(2025, 7, i);
-                slot.setDate(date);
-                slot.setDayOfWeek(date.getDayOfWeek().toString().substring(0, 3).toUpperCase());
-                slot.setDisplayDate(String.format("07/%02d", i));
-
-                // Mock 데이터: 다양한 시간대에 가능
-                if (i == 13) { // 월요일: 10-11시
-                    slot.setTimeBit("0000_0001_1111_0000");
-                } else if (i == 15) { // 수요일: 10-12시
-                    slot.setTimeBit("0000_0001_1111_0000");
-                } else if (i == 17) { // 금요일: 11-12시
-                    slot.setTimeBit("0000_0001_1111_0000");
-                } else {
-                    slot.setTimeBit("0000_0001_1111_0000"); // 불가능
-                }
-                member2Slots.add(slot);
-            }
-            member2.setDailyTimeSlots(member2Slots);
-
-            // 세 번째 멤버 (아직 확정 안함)
-            AllTimeScheduleResponse.MemberSchedule member3 = new AllTimeScheduleResponse.MemberSchedule();
-            member3.setEventMemberId("google_5678");
-            member3.setMemberName("박민수");
-            member3.setRole("MEMBER");
-            member3.setIsConfirmed(false);
-
-            List<AllTimeScheduleResponse.DailyTimeSlot> member3Slots = new ArrayList<>();
-            for (int i = 13; i <= 19; i++) {
-                AllTimeScheduleResponse.DailyTimeSlot slot = new AllTimeScheduleResponse.DailyTimeSlot();
-                LocalDate date = LocalDate.of(2025, 7, i);
-                slot.setDate(date);
-                slot.setDayOfWeek(date.getDayOfWeek().toString().substring(0, 3).toUpperCase());
-                slot.setDisplayDate(String.format("07/%02d", i));
-                slot.setTimeBit("0000_0000_0000_0000"); // 아직 시간 입력 안함
-                member3Slots.add(slot);
-            }
-            member3.setDailyTimeSlots(member3Slots);
-
-            memberSchedules.add(member1);
-            memberSchedules.add(member2);
-            memberSchedules.add(member3);
-            response.setMemberSchedules(memberSchedules);
+            AllTimeScheduleDto dto = eventService.getAllTimeSchedules(eventId, currentMemberId);
+            AllTimeScheduleResponse response = AllTimeScheduleDto.fromDto(dto);
 
             return ResponseEntity.ok(ApiResponse.success(response));
 
+        } catch (NotFoundException e) {
+            return ResponseEntity.status(404)
+                .body(ApiResponse.error(ResponseCode.NOT_FOUND, e.getMessage()));
+
+        } catch (IllegalStateException e) {
+            return ResponseEntity.status(403)
+                .body(ApiResponse.error(ResponseCode.UNAUTHORIZED, e.getMessage()));
+
         } catch (Exception e) {
-            if (e instanceof AuthenticationException) {
-                return ResponseEntity.status(401).body(ApiResponse.error(ResponseCode.UNAUTHORIZED, "권한이 없습니다."));
-            }
-            return ResponseEntity.status(400)
-                .body(ApiResponse.error(ResponseCode.BAD_REQUEST, "서버가 요청을 처리할 수 없습니다."));
+            return ResponseEntity.status(500)
+                .body(ApiResponse.error(ResponseCode.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."));
         }
     }
 

--- a/src/main/java/com/grepp/spring/app/controller/api/event/payload/response/AllTimeScheduleResponse.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/event/payload/response/AllTimeScheduleResponse.java
@@ -1,9 +1,9 @@
 package com.grepp.spring.app.controller.api.event.payload.response;
 
-import java.time.LocalDate;
-import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
+
+import java.util.List;
 
 @Getter
 @Setter
@@ -18,9 +18,17 @@ public class AllTimeScheduleResponse {
     @Getter
     @Setter
     public static class TimeTable {
-        private List<String> dates;
+        private List<DateInfo> dates;
         private String startTime;
         private String endTime;
+    }
+
+    @Getter
+    @Setter
+    public static class DateInfo {
+        private String date;
+        private String dayOfWeek;
+        private String displayDate;
     }
 
     @Getter
@@ -28,7 +36,6 @@ public class AllTimeScheduleResponse {
     public static class MemberSchedule {
         private String eventMemberId;
         private String memberName;
-        private String role;
         private List<DailyTimeSlot> dailyTimeSlots;
         private Boolean isConfirmed;
     }
@@ -36,9 +43,7 @@ public class AllTimeScheduleResponse {
     @Getter
     @Setter
     public static class DailyTimeSlot {
-        private LocalDate date;
-        private String dayOfWeek; // "MON", "TUE", "WED", etc.
-        private String displayDate; // "07-13" 형태
-        private String timeBit; // 해당 멤버의 가능한 시간 비트
+        private String date;
+        private String timeBit;
     }
 }

--- a/src/main/java/com/grepp/spring/app/model/event/dto/AllTimeScheduleDto.java
+++ b/src/main/java/com/grepp/spring/app/model/event/dto/AllTimeScheduleDto.java
@@ -1,0 +1,133 @@
+package com.grepp.spring.app.model.event.dto;
+
+import com.grepp.spring.app.controller.api.event.payload.response.AllTimeScheduleResponse;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+public class AllTimeScheduleDto {
+    private final Long eventId;
+    private final String eventTitle;
+    private final TimeTableDto timeTable;
+    private final List<MemberScheduleDto> memberSchedules;
+    private final Integer totalMembers;
+    private final Integer confirmedMembers;
+
+    @Getter
+    @Builder
+    public static class TimeTableDto {
+        private final List<DateInfoDto> dates;
+        private final String startTime;
+        private final String endTime;
+    }
+
+    @Getter
+    @Builder
+    public static class DateInfoDto {
+        private final String date;
+        private final String dayOfWeek;
+        private final String displayDate;
+    }
+
+    @Getter
+    @Builder
+    public static class MemberScheduleDto {
+        private final String eventMemberId;
+        private final String memberName;
+        private final List<DailyTimeSlotDto> dailyTimeSlots;
+        private final Boolean isConfirmed;
+    }
+
+    @Getter
+    @Builder
+    public static class DailyTimeSlotDto {
+        private final String date;
+        private final String timeBit;
+    }
+
+    public static AllTimeScheduleResponse fromDto(AllTimeScheduleDto dto) {
+        AllTimeScheduleResponse response = new AllTimeScheduleResponse();
+
+        response.setEventId(dto.getEventId());
+        response.setEventTitle(dto.getEventTitle());
+        response.setTotalMembers(dto.getTotalMembers());
+        response.setConfirmedMembers(dto.getConfirmedMembers());
+
+        if (dto.getTimeTable() != null) {
+            AllTimeScheduleResponse.TimeTable timeTable = new AllTimeScheduleResponse.TimeTable();
+
+            if (dto.getTimeTable().getDates() != null) {
+                List<AllTimeScheduleResponse.DateInfo> dateInfos = dto.getTimeTable().getDates().stream()
+                    .map(AllTimeScheduleDto::convertDateInfo)
+                    .collect(Collectors.toList());
+                timeTable.setDates(dateInfos);
+            }
+
+            timeTable.setStartTime(dto.getTimeTable().getStartTime());
+            timeTable.setEndTime(dto.getTimeTable().getEndTime());
+            response.setTimeTable(timeTable);
+        }
+
+        if (dto.getMemberSchedules() != null) {
+            List<AllTimeScheduleResponse.MemberSchedule> memberSchedules = dto.getMemberSchedules().stream()
+                .map(AllTimeScheduleDto::convertMemberSchedule)
+                .collect(Collectors.toList());
+            response.setMemberSchedules(memberSchedules);
+        }
+
+        return response;
+    }
+
+    private static AllTimeScheduleResponse.DateInfo convertDateInfo(DateInfoDto dto) {
+        AllTimeScheduleResponse.DateInfo dateInfo = new AllTimeScheduleResponse.DateInfo();
+        dateInfo.setDate(dto.getDate());
+        dateInfo.setDayOfWeek(dto.getDayOfWeek());
+        dateInfo.setDisplayDate(dto.getDisplayDate());
+        return dateInfo;
+    }
+
+    private static AllTimeScheduleResponse.MemberSchedule convertMemberSchedule(MemberScheduleDto dto) {
+        AllTimeScheduleResponse.MemberSchedule memberSchedule = new AllTimeScheduleResponse.MemberSchedule();
+
+        memberSchedule.setEventMemberId(dto.getEventMemberId());
+        memberSchedule.setMemberName(dto.getMemberName());
+        memberSchedule.setIsConfirmed(dto.getIsConfirmed());
+
+        if (dto.getDailyTimeSlots() != null) {
+            List<AllTimeScheduleResponse.DailyTimeSlot> dailyTimeSlots = dto.getDailyTimeSlots().stream()
+                .map(AllTimeScheduleDto::convertDailyTimeSlot)
+                .collect(Collectors.toList());
+            memberSchedule.setDailyTimeSlots(dailyTimeSlots);
+        }
+
+        return memberSchedule;
+    }
+
+    private static AllTimeScheduleResponse.DailyTimeSlot convertDailyTimeSlot(DailyTimeSlotDto dto) {
+        AllTimeScheduleResponse.DailyTimeSlot dailyTimeSlot = new AllTimeScheduleResponse.DailyTimeSlot();
+        dailyTimeSlot.setDate(dto.getDate());
+        dailyTimeSlot.setTimeBit(dto.getTimeBit());
+        return dailyTimeSlot;
+    }
+
+    public static String formatTimeBit(Long timeBit) {
+        if (timeBit == null || timeBit == 0) {
+            return "000000000000";
+        }
+        return String.format("%012X", timeBit);
+    }
+
+    public static String formatDisplayDate(LocalDate date) {
+        return date.format(DateTimeFormatter.ofPattern("MM/dd"));
+    }
+
+    public static String formatDayOfWeek(LocalDate date) {
+        return date.getDayOfWeek().toString().substring(0, 3).toUpperCase();
+    }
+}

--- a/src/main/java/com/grepp/spring/app/model/event/entity/EventMember.java
+++ b/src/main/java/com/grepp/spring/app/model/event/entity/EventMember.java
@@ -23,6 +23,9 @@ public class EventMember extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Role role;
 
+    @Column(nullable = false)
+    private Boolean confirmed = false;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;

--- a/src/main/java/com/grepp/spring/app/model/event/repository/CandidateDateRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/event/repository/CandidateDateRepository.java
@@ -3,6 +3,10 @@ package com.grepp.spring.app.model.event.repository;
 import com.grepp.spring.app.model.event.entity.CandidateDate;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CandidateDateRepository extends JpaRepository<CandidateDate, Long> {
+
+    List<CandidateDate> findAllByEventIdAndActivatedTrueOrderByDate(Long eventId);
 
 }

--- a/src/main/java/com/grepp/spring/app/model/event/repository/EventMemberRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/event/repository/EventMemberRepository.java
@@ -3,6 +3,7 @@ package com.grepp.spring.app.model.event.repository;
 import com.grepp.spring.app.model.event.entity.EventMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface EventMemberRepository extends JpaRepository<EventMember, Long> {
@@ -12,5 +13,7 @@ public interface EventMemberRepository extends JpaRepository<EventMember, Long> 
     Boolean existsByEventIdAndMemberId(Long eventId, String memberId);
 
     Optional<EventMember> findByEventIdAndMemberIdAndActivatedTrue(Long eventId, String memberId);
+
+    List<EventMember> findAllByEventIdAndActivatedTrue(Long eventId);
 
 }

--- a/src/main/java/com/grepp/spring/app/model/event/repository/TempScheduleRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/event/repository/TempScheduleRepository.java
@@ -1,13 +1,17 @@
 package com.grepp.spring.app.model.event.repository;
 
+import com.grepp.spring.app.model.event.entity.EventMember;
 import com.grepp.spring.app.model.event.entity.TempSchedule;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 public interface TempScheduleRepository extends JpaRepository<TempSchedule, Long> {
 
     Optional<TempSchedule> findByEventMemberIdAndDateAndActivatedTrue(Long eventMemberId, LocalDate date);
+
+    List<TempSchedule> findAllByEventMemberInAndActivatedTrueOrderByEventMemberIdAscDateAsc(List<EventMember> eventMembers);
 
 }

--- a/src/main/java/com/grepp/spring/app/model/event/service/EventService.java
+++ b/src/main/java/com/grepp/spring/app/model/event/service/EventService.java
@@ -26,7 +26,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -176,6 +178,107 @@ public class EventService {
             TempSchedule newSchedule = MyTimeScheduleDto.DailyTimeSlotDto.toEntity(slot, eventMember);
             tempScheduleRepository.save(newSchedule);
         }
+    }
+
+    @Transactional(readOnly = true)
+    public AllTimeScheduleDto getAllTimeSchedules(Long eventId, String currentMemberId) {
+        Event event = eventRepository.findById(eventId)
+            .orElseThrow(() -> new NotFoundException("존재하지 않는 이벤트입니다. ID: " + eventId));
+
+        if (!eventMemberRepository.existsByEventIdAndMemberId(eventId, currentMemberId)) {
+            throw new IllegalStateException("해당 이벤트에 참여하지 않은 사용자입니다.");
+        }
+
+        List<CandidateDate> candidateDates = candidateDateRepository
+            .findAllByEventIdAndActivatedTrueOrderByDate(eventId);
+
+        List<EventMember> eventMembers = eventMemberRepository
+            .findAllByEventIdAndActivatedTrue(eventId);
+
+        Map<Long, List<TempSchedule>> memberScheduleMap = getMemberScheduleMap(eventMembers);
+
+        AllTimeScheduleDto.TimeTableDto timeTable = buildTimeTable(candidateDates);
+
+        List<AllTimeScheduleDto.MemberScheduleDto> memberSchedules = eventMembers.stream()
+            .map(member -> buildSingleMemberSchedule(member, candidateDates, memberScheduleMap))
+            .collect(Collectors.toList());
+
+        Integer confirmedMembers = (int) eventMembers.stream()
+            .filter(EventMember::getConfirmed)
+            .count();
+
+        return AllTimeScheduleDto.builder()
+            .eventId(event.getId())
+            .eventTitle(event.getTitle())
+            .timeTable(timeTable)
+            .memberSchedules(memberSchedules)
+            .totalMembers(eventMembers.size())
+            .confirmedMembers(confirmedMembers)
+            .build();
+    }
+
+    private Map<Long, List<TempSchedule>> getMemberScheduleMap(List<EventMember> eventMembers) {
+        List<TempSchedule> allSchedules = tempScheduleRepository
+            .findAllByEventMemberInAndActivatedTrueOrderByEventMemberIdAscDateAsc(eventMembers);
+
+        return allSchedules.stream()
+            .collect(Collectors.groupingBy(schedule -> schedule.getEventMember().getId()));
+    }
+
+    private AllTimeScheduleDto.TimeTableDto buildTimeTable(List<CandidateDate> candidateDates) {
+        List<AllTimeScheduleDto.DateInfoDto> dateInfos = candidateDates.stream()
+            .map(candidateDate -> {
+                LocalDate date = candidateDate.getDate();
+                return AllTimeScheduleDto.DateInfoDto.builder()
+                    .date(date.toString())
+                    .dayOfWeek(AllTimeScheduleDto.formatDayOfWeek(date))
+                    .displayDate(AllTimeScheduleDto.formatDisplayDate(date))
+                    .build();
+            })
+            .collect(Collectors.toList());
+
+        CandidateDate firstCandidate = candidateDates.getFirst();
+        String startTime = firstCandidate.getStartTime().toString();
+        String endTime = firstCandidate.getEndTime().toString();
+
+        return AllTimeScheduleDto.TimeTableDto.builder()
+            .dates(dateInfos)
+            .startTime(startTime)
+            .endTime(endTime)
+            .build();
+    }
+
+    private AllTimeScheduleDto.MemberScheduleDto buildSingleMemberSchedule(
+        EventMember eventMember,
+        List<CandidateDate> candidateDates,
+        Map<Long, List<TempSchedule>> memberScheduleMap) {
+
+        List<TempSchedule> memberSchedules = memberScheduleMap.getOrDefault(eventMember.getId(), List.of());
+
+        Map<LocalDate, TempSchedule> scheduleByDate = memberSchedules.stream()
+            .collect(Collectors.toMap(TempSchedule::getDate, schedule -> schedule));
+
+        List<AllTimeScheduleDto.DailyTimeSlotDto> dailyTimeSlots = candidateDates.stream()
+            .map(candidateDate -> {
+                LocalDate date = candidateDate.getDate();
+                TempSchedule schedule = scheduleByDate.get(date);
+
+                String timeBit = schedule != null ?
+                    AllTimeScheduleDto.formatTimeBit(schedule.getTimeBit()) : "000000000000";
+
+                return AllTimeScheduleDto.DailyTimeSlotDto.builder()
+                    .date(date.toString())
+                    .timeBit(timeBit)
+                    .build();
+            })
+            .collect(Collectors.toList());
+
+        return AllTimeScheduleDto.MemberScheduleDto.builder()
+            .eventMemberId(eventMember.getMember().getId())
+            .memberName(eventMember.getMember().getName())
+            .dailyTimeSlots(dailyTimeSlots)
+            .isConfirmed(eventMember.getConfirmed())
+            .build();
     }
 
 }

--- a/src/main/java/com/grepp/spring/app/model/event/service/EventService.java
+++ b/src/main/java/com/grepp/spring/app/model/event/service/EventService.java
@@ -2,6 +2,7 @@ package com.grepp.spring.app.model.event.service;
 
 import com.grepp.spring.app.controller.api.event.payload.request.CreateEventRequest;
 import com.grepp.spring.app.controller.api.event.payload.request.MyTimeScheduleRequest;
+import com.grepp.spring.app.controller.api.event.payload.response.AllTimeScheduleResponse;
 import com.grepp.spring.app.model.event.code.Role;
 import com.grepp.spring.app.model.event.dto.*;
 import com.grepp.spring.app.model.event.entity.CandidateDate;
@@ -181,7 +182,7 @@ public class EventService {
     }
 
     @Transactional(readOnly = true)
-    public AllTimeScheduleDto getAllTimeSchedules(Long eventId, String currentMemberId) {
+    public AllTimeScheduleResponse getAllTimeSchedules(Long eventId, String currentMemberId) {
         Event event = eventRepository.findById(eventId)
             .orElseThrow(() -> new NotFoundException("존재하지 않는 이벤트입니다. ID: " + eventId));
 
@@ -207,7 +208,7 @@ public class EventService {
             .filter(EventMember::getConfirmed)
             .count();
 
-        return AllTimeScheduleDto.builder()
+        AllTimeScheduleDto dto = AllTimeScheduleDto.builder()
             .eventId(event.getId())
             .eventTitle(event.getTitle())
             .timeTable(timeTable)
@@ -215,6 +216,8 @@ public class EventService {
             .totalMembers(eventMembers.size())
             .confirmedMembers(confirmedMembers)
             .build();
+
+        return AllTimeScheduleDto.fromDto(dto);
     }
 
     private Map<Long, List<TempSchedule>> getMemberScheduleMap(List<EventMember> eventMembers) {


### PR DESCRIPTION
## ✅ 관련 이슈
- close #36

## 🛠️ 작업 내용
- 참여자 전원의 가능한 시간대 조회 기능

## API 응답 예시
```json
{
  "code": "200",
  "message": "정상적으로 완료되었습니다.",
  "data": {
    "eventId": 1,
    "eventTitle": "스터디 모임",
    "timeTable": {
      "dates": [
        {
          "date": "2025-07-15",
          "dayOfWeek": "TUE",
          "displayDate": "07/15"
        },
        {
          "date": "2025-07-16",
          "dayOfWeek": "WED",
          "displayDate": "07/16"
        },
        {
          "date": "2025-07-17",
          "dayOfWeek": "THU",
          "displayDate": "07/17"
        }
      ],
      "startTime": "09:00",
      "endTime": "18:00"
    },
    "memberSchedules": [
      {
        "eventMemberId": "GOOGLE_113911662543734534236",
        "memberName": "참여자1",
        "dailyTimeSlots": [
          {
            "date": "2025-07-15",
            "timeBit": "000000FC0000"
          },
          {
            "date": "2025-07-16",
            "timeBit": "000000FC0000"
          },
          {
            "date": "2025-07-17",
            "timeBit": "000000000000"
          }
        ],
        "isConfirmed": false
      },
      {
        "eventMemberId": "GOOGLE_1234",
        "memberName": "참여자2",
        "dailyTimeSlots": [
          {
            "date": "2025-07-15",
            "timeBit": "000000000000"
          },
          {
            "date": "2025-07-16",
            "timeBit": "000000FC0000"
          },
          {
            "date": "2025-07-17",
            "timeBit": "000000FC0000"
          }
        ],
        "isConfirmed": false
      }
    ],
    "totalMembers": 2,
    "confirmedMembers": 0
  }
}
```


## 🧩 기타 참고사항
- 이벤트 참여자의 참여 가능 시간대 확정 여부 칼럼이 누락되어 있어 EventMember 엔티티에 추가했습니다. DB 업데이트 부탁드립니다.
- 조회와 관련하여 CQRS 적용은 이벤트 관련 기능이 모두 구현된 뒤에 리팩토링에서 진행 예정입니다.