### PR TITLE
회원 탈퇴 기능 구현 (아직 테스트 필요)

### DIFF
--- a/src/main/java/com/grepp/spring/app/controller/api/auth/AuthController.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/auth/AuthController.java
@@ -85,22 +85,6 @@ public class AuthController {
         }
     }
 
-    @Operation(summary = "회원 탈퇴", description = "서비스 탈퇴를 진행합니다.")
-    @PatchMapping("/deactivate")
-    public ResponseEntity<ApiResponse<?>> deactivate(@Valid @RequestBody AccountDeactivateRequest request) {
-        if (request.getGroupRole().equals(GroupRole.GROUP_LEADER)){
-            return ResponseEntity.status(403)
-                .body(ApiResponse.error(ResponseCode.ADMIN_WITHDRAWAL_NOT_ALLOWED,
-                    Map.of("groups", List.of(new GroupAdminResponse("10001", "대나무행주"),
-                        new GroupAdminResponse("10003", "긔수씨팬클럽")))));
-        } else {
-            return ResponseEntity.ok(ApiResponse.success(
-                new AccountDeactivateResponse("GOOGLE_1234", "ROLE_USER", "하명도")
-            ));
-        }
-    }
-
-
     @Operation(summary = "로그아웃", description = "로그아웃을 진행합니다.")
     @PostMapping("/logout")
     public ResponseEntity<ApiResponse<?>> logout(HttpServletResponse response) {

--- a/src/main/java/com/grepp/spring/app/controller/api/auth/payload/response/GroupAdminResponse.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/auth/payload/response/GroupAdminResponse.java
@@ -7,7 +7,7 @@ import lombok.Data;
 @AllArgsConstructor
 public class GroupAdminResponse {
 
-    private String groupId;
+    private Long groupId;
     private String groupName;
 
 }

--- a/src/main/java/com/grepp/spring/app/controller/api/member/MemberController.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/member/MemberController.java
@@ -11,7 +11,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -52,5 +54,16 @@ public class MemberController {
                 .body(ApiResponse.error(ResponseCode.INTERNAL_SERVER_ERROR, ResponseCode.INTERNAL_SERVER_ERROR.message()));
         }
         // 위 예외들은 추후 GlobalAdvice로 처리하는 방법을 생각중입니다.
+    }
+
+    @Operation(summary = "회원 탈퇴", description = "서비스 탈퇴를 진행합니다.")
+    @DeleteMapping("/withdraw")
+    public ResponseEntity<ApiResponse<?>> withdraw() {
+
+        // SecurityContextHolder 에서 사용자 정보 가져오기
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String userId = authentication.getName();
+        memberService.withdraw(userId);
+        return ResponseEntity.ok(ApiResponse.noContent());
     }
 }

--- a/src/main/java/com/grepp/spring/app/model/group/repository/GroupMemberRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/group/repository/GroupMemberRepository.java
@@ -1,13 +1,31 @@
 package com.grepp.spring.app.model.group.repository;
 
+import com.grepp.spring.app.model.group.entity.Group;
 import com.grepp.spring.app.model.group.entity.GroupMember;
+import com.grepp.spring.app.model.member.entity.Member;
+import io.lettuce.core.dynamic.annotation.Param;
 import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> {
 
     List<GroupMember> findByMemberId(String memberId);
     Optional<GroupMember> findByGroupIdAndMemberId(Long groupId, String memberId);
+
+    // 나중에 적절한 Repository 로 분리 예정
+    @Query("SELECT gm.group FROM GroupMember gm WHERE gm.member = :member AND gm.groupAdmin = true")
+    List<Group> findGroupsByMemberAndAdmin(@Param("member") Member member);
+
+    // 특정 멤버 제외 그룹 내 모든 리더 조회
+    @Query("SELECT gm FROM GroupMember gm WHERE gm.group = :group AND gm.member != :member AND gm.role = 'GROUP_LEADER'")
+    List<GroupMember> findByGroupAndLeaderAndMemberNot(@Param("group") Group group, @Param("member") Member member);
+
+    // 그룹의 모든 멤버 조회
+    List<GroupMember> findByGroup(Group group);
+
+    // 특정 멤버를 GroupMember 에서 삭제
+    void deleteByMember(Member member);
 }

--- a/src/main/java/com/grepp/spring/app/model/member/service/MemberService.java
+++ b/src/main/java/com/grepp/spring/app/model/member/service/MemberService.java
@@ -1,19 +1,124 @@
 package com.grepp.spring.app.model.member.service;
 
+import com.grepp.spring.app.model.group.entity.Group;
+import com.grepp.spring.app.model.group.entity.GroupMember;
+import com.grepp.spring.app.model.group.repository.GroupMemberRepository;
+import com.grepp.spring.app.model.group.repository.GroupRepository;
 import com.grepp.spring.app.model.member.entity.Member;
 import com.grepp.spring.app.model.member.repository.MemberRepository;
+import com.grepp.spring.app.model.schedule.code.ScheduleRole;
+import com.grepp.spring.app.model.schedule.entity.Schedule;
+import com.grepp.spring.app.model.schedule.entity.ScheduleMember;
+import com.grepp.spring.app.model.schedule.repository.ScheduleCommandRepository;
+import com.grepp.spring.app.model.schedule.repository.ScheduleMemberRepository;
+import com.grepp.spring.infra.error.exceptions.member.WithdrawNotAllowedException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
+import java.util.Random;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class MemberService {
 
+    private static final Logger log = LoggerFactory.getLogger(MemberService.class);
     private final MemberRepository memberRepository;
+    private final GroupMemberRepository groupMemberRepository;
+    private final GroupRepository groupRepository;
+    private final ScheduleMemberRepository scheduleMemberRepository;
+    private final ScheduleCommandRepository scheduleCommandRepository;
 
     public Optional<Member> findById(String userId) {
         return memberRepository.findById(userId);
     }
 
+    @Transactional
+    public void withdraw(String userId) {
+        Member member = memberRepository.findById(userId)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+        // 이 사람이 그룹의 관리자인지를 체크
+        // 관리자라면 이 사람이 관리자인 그룹을 전부 조회
+
+        // 본인이 관리자인 그룹 조회
+        List<Group> adminGroups = groupMemberRepository.findGroupsByMemberAndAdmin(member);
+        // 예외처리에 사용할 수퍼 리더를 넘길 수 없는 그룹을 저장할 리스트
+        List<Group> withdrawNotAllowedGroups = new ArrayList<>();
+        // 본인이 수퍼 리더(Admin)인 그룹이 있다면, 각 그룹 별 리더 중 랜덤으로 권한 넘기기
+        if (!adminGroups.isEmpty()){
+            for (Group group : adminGroups){
+                // 각 그룹의 모든 멤바 조회
+                List<GroupMember> groupMembers = groupMemberRepository.findByGroup(group);
+                // 내가 그룹의 유일한 멤바라면 그룹까지 날려버리깅
+                if (groupMembers.size() == 1 && groupMembers.getFirst().getMember().equals(member)){
+                    groupRepository.delete(group);
+                    log.info("그룹 " + group.getName() + "의 유일한 멤버이므로 그룹이 삭제됩니다.");
+                    continue;
+                }
+
+                // 각 그룹의 모든 리더 조회 (나 빼고)
+                List<GroupMember> groupLeaders = groupMemberRepository.findByGroupAndLeaderAndMemberNot(group, member);
+                // 본인 외 다른 멤바가 있다면?
+                if (!groupLeaders.isEmpty()){
+                    // 리더가 존재한다면 랜덤으로 관리자 넘겨버리깅
+                    GroupMember newAdmin = selectRandomMember(groupLeaders);
+
+                    newAdmin.setGroupAdmin(true); // 너 이제부터 수퍼리더야.
+                    groupMemberRepository.save(newAdmin);
+                    log.info("그룹 " + group.getName() + "의 새 관리자가 " + newAdmin.getMember().getName() + "님 으로 위임되었습니다.");
+                }else {
+                    // 리더가 없으면 예외 발생 시켜야하니깐 그룹을 리스트에 추가해두자. 나중에 응답에 쓸거임
+                    withdrawNotAllowedGroups.add(group);
+                    log.info("위임할 리더가 없는 그룹: " + group.getName());
+                }
+            }
+        }
+        // 수퍼 리더 위임이 불가능한 그룹이 있다면 예외처리
+        // 탈퇴 전에 그룹에 리더를 만들어야 해요~~!!
+        if (!withdrawNotAllowedGroups.isEmpty()){
+            throw new WithdrawNotAllowedException("이 그룹에 관리자 권한을 위임할 수 있는 리더를 추가해주세요.", withdrawNotAllowedGroups);
+        }
+
+        // 일정 관리자 처리
+        // 본인이 일정 마스터인 모든 일정 조회
+        List<Schedule> masterSchedules = scheduleMemberRepository.findByMember(member);
+
+        // 본인이 마스터인 일정이 있다면,
+        if (!masterSchedules.isEmpty()){
+            for (Schedule schedule : masterSchedules){
+                // 각 일정 내 모든 멤바 조회 (나 빼고)
+                List<ScheduleMember> scheduleMembers = scheduleMemberRepository.findByScheduleAndMemberNot(schedule, member);
+
+                if (scheduleMembers.isEmpty()){
+                    // 본인이 일정의 유일 멤버라면? 일정 너도 삭제야.
+                    scheduleCommandRepository.delete(schedule);
+                    log.info("일정 " + schedule.getScheduleName() + "의 마지막 멤버이므로 일정이 삭제됩니다.");
+                } else {
+                    // 다른 멤바가 있다면 랜덤으로 관리자 위임
+                    ScheduleMember newScheduleMaster = selectRandomMember(scheduleMembers);
+                    newScheduleMaster.setRole(ScheduleRole.ROLE_MASTER); // 새 관리자로 임명
+                    scheduleMemberRepository.save(newScheduleMaster);
+                    log.info("일정 "+ schedule.getScheduleName() +"의 새 관리자가 " + newScheduleMaster.getMember().getName() + " 님 으로 위임되었습니다.");
+                }
+            }
+        }
+
+        // 연관 테이블에서 삭제 먼저 (양방향 매핑이 아니라서 수동으로..)
+        groupMemberRepository.deleteByMember(member);
+        scheduleMemberRepository.deleteByMember(member);
+        // 이제 진짜 탈퇴.
+        memberRepository.delete(member);
+        log.info("회원 탈퇴가 완료되었습니다. 회원 ID: " + member.getId(), "회원명: ", member.getName());
+    }
+
+    // 다음 리더를 뽑아주는 제네릭 메서드 : 이렇게 하면 그룹이랑 스케줄에서 같이 쓸 수 있습니다
+    private <T> T selectRandomMember(List<T> members) {
+        Random random = new Random();
+        int randomIndex = random.nextInt(members.size());
+        return members.get(randomIndex);
+    }
 }

--- a/src/main/java/com/grepp/spring/app/model/schedule/repository/ScheduleMemberRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/schedule/repository/ScheduleMemberRepository.java
@@ -1,0 +1,23 @@
+package com.grepp.spring.app.model.schedule.repository;
+
+import com.grepp.spring.app.model.member.entity.Member;
+import com.grepp.spring.app.model.schedule.entity.Schedule;
+import com.grepp.spring.app.model.schedule.entity.ScheduleMember;
+import io.lettuce.core.dynamic.annotation.Param;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface ScheduleMemberRepository extends JpaRepository<ScheduleMember, Long> {
+
+    // 특정 멤버가 속하는 일정 리스트 조회
+    @Query("SELECT sm.schedule FROM ScheduleMember sm WHERE sm.member = :member")
+    List<Schedule> findByMember(@Param("member") Member member);
+
+    // 특정 일정에 참여하는 멤버 조회
+    @Query("SELECT sm FROM ScheduleMember sm WHERE sm.schedule = :schedule AND sm.member != :member")
+    List<ScheduleMember> findByScheduleAndMemberNot(@Param("schedule") Schedule schedule, @Param("member") Member member);
+
+    // 특정 멤버를 ScheduleMember 에서 삭제
+    void deleteByMember(Member member);
+}

--- a/src/main/java/com/grepp/spring/infra/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/grepp/spring/infra/auth/jwt/JwtTokenProvider.java
@@ -129,12 +129,7 @@ public class JwtTokenProvider {
     }
     
     public String resolveToken(HttpServletRequest request, AuthToken token) {
-        
-        String headerToken = request.getHeader("Authorization");
-        if (headerToken != null && headerToken.startsWith("Bearer")) {
-            return headerToken.substring(7);
-        }
-        
+
         Cookie[] cookies = request.getCookies();
         if (cookies == null) {
             return null;

--- a/src/main/java/com/grepp/spring/infra/error/MemberExceptionAdvice.java
+++ b/src/main/java/com/grepp/spring/infra/error/MemberExceptionAdvice.java
@@ -1,0 +1,27 @@
+package com.grepp.spring.infra.error;
+
+import com.grepp.spring.app.controller.api.auth.payload.response.GroupAdminResponse;
+import com.grepp.spring.infra.error.exceptions.member.WithdrawNotAllowedException;
+import com.grepp.spring.infra.response.ApiResponse;
+import com.grepp.spring.infra.response.ResponseCode;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice(basePackages = "com.grepp.spring.app.controller.api")
+public class MemberExceptionAdvice {
+
+    @ExceptionHandler(WithdrawNotAllowedException.class)
+    public ResponseEntity<ApiResponse<?>> withdrawNotAllowedExHandler(WithdrawNotAllowedException ex) {
+
+        List<GroupAdminResponse> groups = ex.getLeaderGroups().stream()
+            .map(group -> new GroupAdminResponse(group.getId(), group.getName()))
+            .toList();
+
+        return ResponseEntity.status(403)
+            .body(ApiResponse.error(ResponseCode.BAD_REQUEST, groups));
+    }
+
+}

--- a/src/main/java/com/grepp/spring/infra/error/exceptions/member/WithdrawNotAllowedException.java
+++ b/src/main/java/com/grepp/spring/infra/error/exceptions/member/WithdrawNotAllowedException.java
@@ -1,0 +1,18 @@
+package com.grepp.spring.infra.error.exceptions.member;
+
+import com.grepp.spring.app.model.group.entity.Group;
+import java.util.List;
+
+public class WithdrawNotAllowedException extends RuntimeException {
+
+    private final List<Group> leaderGroups;
+
+    public WithdrawNotAllowedException(String message, List<Group> leaderGroups) {
+        super(message);
+        this.leaderGroups = leaderGroups;
+    }
+
+    public List<Group> getLeaderGroups() {
+        return leaderGroups;
+    }
+}

--- a/src/main/resources/withdraw.sql
+++ b/src/main/resources/withdraw.sql
@@ -1,0 +1,124 @@
+-- 그룹 테이블 생성
+insert into groups(id, name, description, is_grouped, activated)
+values (1,'DOD 그룹','DOD 그룹입니당',true, true);
+
+-- 이벤트 테이블 생성
+insert into events(id, description, max_member, meeting_type, title, group_id, activated)
+values (1,'DOD 이벤트 생성', 10, 'OFFLINE', 'DOD 이벤트', 1, true);
+
+-- 일정 테이블 생성
+insert into schedules(id, start_time, end_time, location, meeting_platform, specific_location, status, event_id, activated, description, schedule_name)
+values (1, '2025-08-09 17:30:00','2025-08-09 23:00:00' , '강남역', 'NONE', '강남역 롯데시네마', 'FIXED',1,true, 'DOD 만나는 날입니당', '모여라! DOD!');
+
+-- 멤버 테이블 생성
+insert into members(id, password, provider, role, email, name, profile_image_number, tel)
+values ('1a', '{noop}123qwe!@#', 'GOOGLE', 'ROLE_USER', 'a@mail.com','이서준', 1, '010-1111-1111');
+
+insert into members(id, password, provider, role, email, name, profile_image_number, tel)
+values ('2a', '{noop}123qwe!@#', 'GOOGLE', 'ROLE_USER', 'x@mail.com','이강현', 1, '010-1111-1112');
+
+insert into members(id, password, provider, role, email, name, profile_image_number, tel)
+values ('3a', '{noop}123qwe!@#', 'GOOGLE', 'ROLE_USER', 'b@mail.com','안준희', 1, '010-1111-1113');
+
+insert into members(id, password, provider, role, email, name, profile_image_number, tel)
+values ('4a', '{noop}123qwe!@#', 'GOOGLE', 'ROLE_USER', 'c@mail.com','정서윤', 1, '010-1111-1114');
+
+insert into members(id, password, provider, role, email, name, profile_image_number, tel)
+values ('5a', '{noop}123qwe!@#', 'GOOGLE', 'ROLE_USER', 'd@mail.com','최동준', 1, '010-1111-1115');
+
+insert into members(id, password, provider, role, email, name, profile_image_number, tel)
+values ('6a', '{noop}123qwe!@#', 'GOOGLE', 'ROLE_USER', 'e@mail.com','박상윤', 1, '010-1111-1116');
+
+insert into members(id, password, provider, role, email, name, profile_image_number, tel)
+values ('7a', '{noop}123qwe!@#', 'GOOGLE', 'ROLE_USER', 'f@mail.com','박은서', 1, '010-1111-1117');
+
+insert into members(id, password, provider, role, email, name, profile_image_number, tel)
+values ('8a', '{noop}123qwe!@#', 'GOOGLE', 'ROLE_USER', 'g@mail.com','박준규', 1, '010-1111-1118');
+
+insert into members(id, password, provider, role, email, name, profile_image_number, tel)
+values ('9a', '{noop}123qwe!@#', 'GOOGLE', 'ROLE_USER', 'h@mail.com','현혜주', 1, '010-1111-1119');
+
+insert into members(id, password, provider, role, email, name, profile_image_number, tel)
+values ('10a', '{noop}123qwe!@#', 'GOOGLE', 'ROLE_USER', 'i@mail.com','황수지', 1, '010-1111-1121');
+
+insert into members(id, password, provider, role, email, name, profile_image_number, tel)
+values ('11a', '{noop}123qwe!@#', 'GOOGLE', 'ROLE_USER', 'j@mail.com','홍길동', 1, '010-1111-1131');
+
+insert into members(id, password, provider, role, email, name, profile_image_number, tel)
+values ('12a', '{noop}123qwe!@#', 'GOOGLE', 'ROLE_USER', 'k@mail.com','길동이', 1, '010-1111-1141');
+
+insert into members(id, password, provider, role, email, name, profile_image_number, tel)
+values ('13a', '{noop}123qwe!@#', 'GOOGLE', 'ROLE_USER', 'z@mail.com','해리포터', 1, '010-1111-5111');
+
+-- schedule_member 테이블 생성
+insert into schedule_members(id, member_id, schedule_id, role, depart_location_name, latitude, longitude, name)
+values (1,'1a',1, 'ROLE_MASTER','서울역', 321.1234, 126.972836, '이서준');
+
+insert into schedule_members(id, member_id, schedule_id, role, depart_location_name, latitude, longitude, name)
+values (2,'2a',1, 'ROLE_MEMBER','건대입구역', 37.540882, 127.071103, '이강현');
+
+insert into schedule_members(id, member_id, schedule_id, role, depart_location_name, latitude, longitude, name)
+values (3,'3a',1, 'ROLE_MEMBER','강남역', 37.497958, 127.027539, '안준희');
+
+insert into schedule_members(id, member_id, schedule_id, role, depart_location_name, latitude, longitude, name)
+values (4,'4a',1, 'ROLE_MEMBER','홍대입구역', 37.556748, 126.923643, '정서윤');
+
+insert into schedule_members(id, member_id, schedule_id, role, depart_location_name, latitude, longitude, name)
+values (5,'5a',1, 'ROLE_MEMBER','잠실역', 37.514649, 127.104267, '최동준');
+
+insert into schedule_members(id, member_id, schedule_id, role, depart_location_name, latitude, longitude, name)
+values (6,'6a',1, 'ROLE_MEMBER','사당역', 37.476536, 126.981631, '박상윤');
+
+insert into schedule_members(id, member_id, schedule_id, role, depart_location_name, latitude, longitude, name)
+values (7,'7a',1, 'ROLE_MEMBER','을지로입구역', 37.565998, 126.982569, '박은서');
+
+insert into schedule_members(id, member_id, schedule_id, role, depart_location_name, latitude, longitude, name)
+values (8,'8a',1, 'ROLE_MEMBER','안국역', 37.576562, 126.98547, '박준규');
+
+insert into schedule_members(id, member_id, schedule_id, role, depart_location_name, latitude, longitude, name)
+values (9,'9a',1, 'ROLE_MEMBER','역삼역', 37.500658, 127.03643, '현혜주');
+
+insert into schedule_members(id, member_id, schedule_id, role, depart_location_name, latitude, longitude, name)
+values (10,'10a',1, 'ROLE_MEMBER','이수역', 37.487521, 126.982309, '황수지');
+
+-- 그룹 멤버 삽입 (최동준: super leader)
+insert into group_members(id, role, member_id, group_id, group_admin)
+values (10000, 'GROUP_LEADER', '5a', 1, true);
+
+-- 나머지 GROUP_LEADER 4명 (groupAdmin: false)
+insert into group_members(id, role, member_id, group_id, group_admin)
+values (10001, 'GROUP_LEADER', '1a', 1, false);
+
+insert into group_members(id, role, member_id, group_id, group_admin)
+values (10002, 'GROUP_LEADER', '2a', 1, false);
+
+insert into group_members(id, role, member_id, group_id, group_admin)
+values (10003, 'GROUP_LEADER', '3a', 1, false);
+
+insert into group_members(id, role, member_id, group_id, group_admin)
+values (10004, 'GROUP_LEADER', '4a', 1, false);
+
+-- 나머지 8명은 GROUP_MEMBER
+insert into group_members(id, role, member_id, group_id, group_admin)
+values (10005, 'GROUP_MEMBER', '6a', 1, false);
+
+insert into group_members(id, role, member_id, group_id, group_admin)
+values (10006, 'GROUP_MEMBER', '7a', 1, false);
+
+insert into group_members(id, role, member_id, group_id, group_admin)
+values (10007, 'GROUP_MEMBER', '8a', 1, false);
+
+insert into group_members(id, role, member_id, group_id, group_admin)
+values (10008, 'GROUP_MEMBER', '9a', 1, false);
+
+insert into group_members(id, role, member_id, group_id, group_admin)
+values (10009, 'GROUP_MEMBER', '10a', 1, false);
+
+insert into group_members(id, role, member_id, group_id, group_admin)
+values (10010, 'GROUP_MEMBER', '11a', 1, false);
+
+insert into group_members(id, role, member_id, group_id, group_admin)
+values (10011, 'GROUP_MEMBER', '12a', 1, false);
+
+insert into group_members(id, role, member_id, group_id, group_admin)
+values (10012, 'GROUP_MEMBER', '13a', 1, false);


### PR DESCRIPTION
## ✅ 관련 이슈
- close #71

## 🛠️ 작업 내용
- 회원 탈퇴 기능을 구현했습니다. 다양한 분기가 존재하는데,
   - 본인이 그룹의 수퍼리더(admin)인 경우
      - 본인이 그룹의 유일한 멤버라면 그룹 삭제 후 탈퇴 
      - 본인을 제외한 리더가 존재한다면 그들 중 랜덤으로 한 명에게 위임 후 탈퇴
      - 본인을 제외한 리더가 존재하지 않고 다른 멤버가 있다면, 새로운 리더를 추가하라는 메시지와 함께 예외 처리(탈퇴 반려)
   - 본인이 일정의 마스터인 경우
      - 일정에 다른 멤버가 존재한다면 그 중 랜덤으로 선택해서 위임 후 탈퇴
      - 본인이 일정의 유일한 멤버라면 일정 삭제 후 탈퇴

## 📸 스크린샷 (선택)
- 아래 API를 호출하여 탈퇴를 진행할 수 있습니다.
<img width="1224" height="772" alt="image" src="https://github.com/user-attachments/assets/a1aff7d9-7b18-4dbc-908b-cfb7cd49d850" />


- 탈퇴 시 로그로 위임된 멤버 명이 나타납니다.
<img width="1285" height="70" alt="image" src="https://github.com/user-attachments/assets/6fcd07bc-fe25-4b6b-a52d-d42e0621d7d4" />


## 🧩 기타 참고사항
- 현재 member와 scheduleMember, scheduleMember 는 단방향 매핑이기 때문에, member 탈퇴 이전에 연관된 매핑들을 수동으로 삭제하고 있습니다. (Hard Delete로 변경)
- 아직 eventMember를 삭제하는 로직은 구현되지 않았는데, 추후 수정하겠습니다.
- 로직이 복잡해서 테스트 코드가 필수적일 것 같습니다.. ㅜ
