### PR TITLE
✨ feat: 구글 캘린더 초기 연동 + 수동 연동

### DIFF
--- a/src/main/java/com/grepp/spring/app/controller/api/mainpage/CalendarController.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/mainpage/CalendarController.java
@@ -4,6 +4,7 @@ package com.grepp.spring.app.controller.api.mainpage;
 import com.grepp.spring.app.controller.api.mypage.payload.response.CalendarSyncStatusResponse;
 import com.grepp.spring.app.model.auth.domain.Principal;
 import com.grepp.spring.app.model.mainpage.service.CalendarService;
+import com.grepp.spring.app.model.mypage.service.CalendarSyncService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
@@ -18,18 +19,19 @@ import org.springframework.web.bind.annotation.RestController;
 public class CalendarController {
 
   private final CalendarService calendarService;
+  private final CalendarSyncService calendarSyncService;
 
-//  @GetMapping("/sync-status")
-//  public ResponseEntity<CalendarSyncStatusResponse> getCalendar(
-//      @AuthenticationPrincipal Principal principal
-//  ) {
-//
-//    if (principal == null) {
-//      throw new AuthenticationCredentialsNotFoundException("로그인 필요");
-//    }
-//
-//    CalendarSyncStatusResponse response = calendarService.getCalendarSyncStatus(principal.getUsername());
-//    return ResponseEntity.ok(response);
-//  }
+  @GetMapping("/sync-status")
+  public ResponseEntity<CalendarSyncStatusResponse> getCalendar(
+      @AuthenticationPrincipal Principal principal
+  ) {
+
+    if (principal == null) {
+      throw new AuthenticationCredentialsNotFoundException("로그인 필요");
+    }
+
+    CalendarSyncStatusResponse response = calendarSyncService.getCalendarSyncStatus(principal.getUsername());
+    return ResponseEntity.ok(response);
+  }
 
 }

--- a/src/main/java/com/grepp/spring/app/controller/api/mainpage/CalendarController.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/mainpage/CalendarController.java
@@ -15,23 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("api/v1/calendar")
+@RequestMapping()
 public class CalendarController {
-
-  private final CalendarService calendarService;
-  private final CalendarSyncService calendarSyncService;
-
-  @GetMapping("/sync-status")
-  public ResponseEntity<CalendarSyncStatusResponse> getCalendar(
-      @AuthenticationPrincipal Principal principal
-  ) {
-
-    if (principal == null) {
-      throw new AuthenticationCredentialsNotFoundException("로그인 필요");
-    }
-
-    CalendarSyncStatusResponse response = calendarSyncService.getCalendarSyncStatus(principal.getUsername());
-    return ResponseEntity.ok(response);
-  }
 
 }

--- a/src/main/java/com/grepp/spring/app/controller/api/mypage/payload/response/SetCalendarSyncResponse.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/mypage/payload/response/SetCalendarSyncResponse.java
@@ -1,11 +1,14 @@
 package com.grepp.spring.app.controller.api.mypage.payload.response;
 
 import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
+@AllArgsConstructor
 public class SetCalendarSyncResponse {
   private boolean isSynced; // 동기화 on/off 여부
   private LocalDateTime lastSyncAt; // 마지막 동기화 시점

--- a/src/main/java/com/grepp/spring/app/controller/api/mypage/payload/response/SetCalendarSyncResponse.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/mypage/payload/response/SetCalendarSyncResponse.java
@@ -1,8 +1,8 @@
 package com.grepp.spring.app.controller.api.mypage.payload.response;
 
 import java.time.LocalDateTime;
+import javax.annotation.Nullable;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -11,6 +11,7 @@ import lombok.Setter;
 @AllArgsConstructor
 public class SetCalendarSyncResponse {
   private boolean isSynced; // 동기화 on/off 여부
-  private LocalDateTime lastSyncAt; // 마지막 동기화 시점
+  private LocalDateTime syncUpdatedAt; // lastSyncedAt 에서 변경. 연동 끊었을 때 시간 반영 고려
+  private String reauthUrl; // 재연동 할 때만 필요한 구글 OAuth 인증 URL. Nullable
 
 }

--- a/src/main/java/com/grepp/spring/app/model/auth/AuthService.java
+++ b/src/main/java/com/grepp/spring/app/model/auth/AuthService.java
@@ -4,12 +4,15 @@ import com.grepp.spring.app.controller.api.auth.Provider;
 import com.grepp.spring.app.controller.api.auth.payload.request.LoginRequest;
 import com.grepp.spring.app.model.auth.dto.TokenDto;
 import com.grepp.spring.app.model.auth.token.entity.RefreshToken;
+import com.grepp.spring.app.model.mainpage.entity.Calendar;
 import com.grepp.spring.app.model.member.code.Role;
 import com.grepp.spring.app.model.member.entity.Member;
 import com.grepp.spring.app.model.member.repository.MemberRepository;
+import com.grepp.spring.app.model.mypage.repository.CalendarRepository;
 import com.grepp.spring.infra.auth.jwt.JwtTokenProvider;
 import com.grepp.spring.infra.auth.jwt.dto.AccessTokenDto;
 import com.grepp.spring.infra.auth.oauth2.user.OAuth2UserInfo;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.Random;
 import lombok.RequiredArgsConstructor;
@@ -32,6 +35,7 @@ public class AuthService {
     private final JwtTokenProvider jwtTokenProvider;
     private final MemberRepository memberRepository;
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private final CalendarRepository calendarRepository;
 
     public TokenDto signin(LoginRequest loginRequest) {
         UsernamePasswordAuthenticationToken authenticationToken =
@@ -72,6 +76,19 @@ public class AuthService {
             // 프로필 사진은 모르겠다 일단 아무 숫자나 넣자
             memberRepository.save(member);
             log.info("새로운 유저 DB에 저장 완료: {}", userId);
+
+
+            member = memberRepository.save(member); // 저장된 것에서 member 객체 다시 받기
+
+            // 캘린더 생성
+            Calendar calendar = new Calendar();
+            calendar.setMember(member);
+            calendar.setName("ittaeok");
+            calendar.setSynced(false);
+            calendar.setSyncedAt(LocalDateTime.now());
+            calendarRepository.save(calendar);
+
+            log.info("새로운 유저 및 캘린더 저장 완료: {}", userId);
         }
 
         AccessTokenDto accessToken = jwtTokenProvider.generateAccessToken(userId, Role.ROLE_USER.name());

--- a/src/main/java/com/grepp/spring/app/model/auth/AuthService.java
+++ b/src/main/java/com/grepp/spring/app/model/auth/AuthService.java
@@ -85,7 +85,7 @@ public class AuthService {
             calendar.setMember(member);
             calendar.setName("ittaeok");
             calendar.setSynced(false);
-            calendar.setSyncedAt(LocalDateTime.now());
+            calendar.setSyncUpdatedAt(LocalDateTime.now());
             calendarRepository.save(calendar);
 
             log.info("새로운 유저 및 캘린더 저장 완료: {}", userId);

--- a/src/main/java/com/grepp/spring/app/model/mainpage/entity/Calendar.java
+++ b/src/main/java/com/grepp/spring/app/model/mainpage/entity/Calendar.java
@@ -44,7 +44,7 @@ public class Calendar extends BaseEntity {
     private Boolean synced;
 
     @Column(nullable = false)
-    private LocalDateTime syncedAt;
+    private LocalDateTime syncUpdatedAt; // lastSyncedAt 에서 변경
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", unique = true)

--- a/src/main/java/com/grepp/spring/app/model/mainpage/service/CalendarService.java
+++ b/src/main/java/com/grepp/spring/app/model/mainpage/service/CalendarService.java
@@ -1,6 +1,5 @@
 package com.grepp.spring.app.model.mainpage.service;
 
-import com.grepp.spring.app.controller.api.mypage.payload.response.CalendarSyncStatusResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -8,7 +7,6 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class CalendarService {
 
-//  public CalendarSyncStatusResponse getCalendarSyncStatus(String username) {
-//    return CalendarSyncStatusResponse;
-//  }
+
+
 }

--- a/src/main/java/com/grepp/spring/app/model/member/entity/SocialAuthToken.java
+++ b/src/main/java/com/grepp/spring/app/model/member/entity/SocialAuthToken.java
@@ -1,8 +1,11 @@
 package com.grepp.spring.app.model.member.entity;
 
+import com.grepp.spring.app.controller.api.auth.Provider;
 import com.grepp.spring.infra.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -48,8 +51,9 @@ public class SocialAuthToken extends BaseEntity {
     @Column(nullable = false)
     private LocalDateTime expiresAt;
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private String provider;
+    private Provider provider;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")

--- a/src/main/java/com/grepp/spring/app/model/member/repository/SocialAuthTokenRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/member/repository/SocialAuthTokenRepository.java
@@ -3,10 +3,12 @@ package com.grepp.spring.app.model.member.repository;
 import com.grepp.spring.app.controller.api.auth.Provider;
 import com.grepp.spring.app.model.member.entity.Member;
 import com.grepp.spring.app.model.member.entity.SocialAuthToken;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SocialAuthTokenRepository extends JpaRepository<SocialAuthToken, Long> {
 
   void deleteByMemberAndProvider(Member member, Provider provider);
 
+  Optional<SocialAuthToken> findByMember(Member member);
 }

--- a/src/main/java/com/grepp/spring/app/model/mypage/dto/GoogleEventDto.java
+++ b/src/main/java/com/grepp/spring/app/model/mypage/dto/GoogleEventDto.java
@@ -1,0 +1,16 @@
+package com.grepp.spring.app.model.mypage.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class GoogleEventDto {
+  private String googleEventId;  // 구글 이벤트 ID -> 구글에선 '일정'이 또 '이벤트'라네요
+  private String title;          // summary
+  private LocalDateTime start;
+  private LocalDateTime end;
+}

--- a/src/main/java/com/grepp/spring/app/model/mypage/repository/CalendarRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/mypage/repository/CalendarRepository.java
@@ -1,0 +1,15 @@
+package com.grepp.spring.app.model.mypage.repository;
+
+
+import com.grepp.spring.app.model.mainpage.entity.Calendar;
+import com.grepp.spring.app.model.member.entity.Member;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CalendarRepository extends JpaRepository<Calendar, Long> {
+
+
+  Optional<Calendar> findByMember(Member member);
+}

--- a/src/main/java/com/grepp/spring/app/model/mypage/service/CalendarSyncService.java
+++ b/src/main/java/com/grepp/spring/app/model/mypage/service/CalendarSyncService.java
@@ -2,40 +2,137 @@ package com.grepp.spring.app.model.mypage.service;
 
 import com.grepp.spring.app.controller.api.mypage.payload.request.SetCalendarSyncRequest;
 import com.grepp.spring.app.controller.api.mypage.payload.response.CalendarSyncStatusResponse;
+import com.grepp.spring.app.controller.api.mypage.payload.response.GoogleTokenResponse;
+import com.grepp.spring.app.controller.api.mypage.payload.response.SetCalendarSyncResponse;
 import com.grepp.spring.app.model.mainpage.entity.Calendar;
 import com.grepp.spring.app.model.member.entity.Member;
+import com.grepp.spring.app.model.member.entity.SocialAuthToken;
 import com.grepp.spring.app.model.member.repository.MemberRepository;
+import com.grepp.spring.app.model.member.repository.SocialAuthTokenRepository;
+import com.grepp.spring.app.model.mypage.dto.GoogleEventDto;
 import com.grepp.spring.app.model.mypage.repository.CalendarRepository;
+import com.grepp.spring.infra.response.ApiResponse;
+import com.grepp.spring.infra.response.ResponseCode;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
 
 @Service
 @RequiredArgsConstructor
 public class CalendarSyncService {
 
   private final MemberRepository memberRepository;
+  private final SocialAuthTokenRepository socialAuthTokenRepository;
   private final CalendarRepository calendarRepository;
+  private final SocialAuthTokenService socialAuthTokenService; // refresh_token → access_token 자동 갱신 담당
+  private final GoogleOAuthService googleOAuthService;
 
-  public void updateSyncSetting(String memberId, SetCalendarSyncRequest request) {
+  private final RestTemplate restTemplate = new RestTemplate();
+
+  // ✅ 캘린더 동기화 (매번 새로고침 방식)
+  public ApiResponse<List<GoogleEventDto>> syncCalendar(String memberId) {
+
+    // 1) 회원 조회
     Member member = memberRepository.findById(memberId)
         .orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다."));
 
-    Calendar calendar = calendarRepository.findByMember(member)
-        .orElseThrow(() -> new IllegalStateException("캘린더가 존재하지 않습니다."));
+    // 2) 사용자 구글 토큰 조회
+    Optional<SocialAuthToken> tokenOpt = socialAuthTokenRepository.findByMember(member);
 
-    calendar.setSynced(request.isSynced());
-    calendar.setSyncedAt(LocalDateTime.now());
+    if (tokenOpt.isEmpty()) {
+      // // 아예 연동 안 된 상태 → 재인증 필요
+      return ApiResponse.error(ResponseCode.UNAUTHORIZED, googleOAuthService.buildReauthUrl());
+    }
 
-    calendarRepository.save(calendar); // 변경사항 저장
+    SocialAuthToken token = tokenOpt.get();
+
+    // 3) refresh_token으로 유효한 access_token 확보 (만료 시 자동 갱신)
+    String accessToken = socialAuthTokenService.getValidAccessToken(token);
+
+    if (accessToken == null) {
+      // // refresh_token 무효 → 재인증 필요
+      return ApiResponse.error(ResponseCode.UNAUTHORIZED, googleOAuthService.buildReauthUrl());
+    }
+
+    // 4) ✅ 구글 캘린더 API 직접 호출
+    HttpHeaders headers = new HttpHeaders();
+    headers.setBearerAuth(accessToken);
+
+    HttpEntity<String> entity = new HttpEntity<>(headers);
+
+    ResponseEntity<Map> response = restTemplate.exchange(
+        "https://www.googleapis.com/calendar/v3/calendars/primary/events",
+        HttpMethod.GET,
+        entity,
+        Map.class
+    );
+
+    // 5) ✅ 구글 응답 → DTO 변환
+    List<Map<String, Object>> items = (List<Map<String, Object>>) response.getBody().get("items");
+    List<GoogleEventDto> events = convertToDto(items);
+
+    // // 최신 이벤트 반환
+    return ApiResponse.success(events);
   }
 
+  // ✅ Google JSON → DTO 변환
+  private List<GoogleEventDto> convertToDto(List<Map<String, Object>> items) {
+    List<GoogleEventDto> events = new ArrayList<>();
+
+    if (items != null) {
+      for (Map<String, Object> item : items) {
+        String id = (String) item.get("id");
+        String summary = (String) item.get("summary");
+
+        Map<String, String> startMap = (Map<String, String>) item.get("start");
+        Map<String, String> endMap = (Map<String, String>) item.get("end");
+
+        // dateTime 우선, 없으면 date 사용
+        String startDateTime = startMap.get("dateTime");
+        String endDateTime = endMap.get("dateTime");
+
+        LocalDateTime start;
+        LocalDateTime end;
+
+        if (startDateTime != null) {
+          start = LocalDateTime.parse(startDateTime, DateTimeFormatter.ISO_DATE_TIME);
+        } else {
+          // 종일 이벤트 → date(YYYY-MM-DD)를 LocalDateTime으로 변환
+          start = LocalDate.parse(startMap.get("date"), DateTimeFormatter.ISO_DATE).atStartOfDay();
+        }
+
+        if (endDateTime != null) {
+          end = LocalDateTime.parse(endDateTime, DateTimeFormatter.ISO_DATE_TIME);
+        } else {
+          end = LocalDate.parse(endMap.get("date"), DateTimeFormatter.ISO_DATE).atStartOfDay();
+        }
+
+        events.add(new GoogleEventDto(id, summary, start, end));
+      }
+    }
+    return events;
+  }
+
+
+  // ✅ 연동 상태 조회 (원하면 유지)
   public CalendarSyncStatusResponse getCalendarSyncStatus(String memberId) {
     Member member = memberRepository.findById(memberId)
         .orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다."));
 
     Calendar calendar = calendarRepository.findByMember(member)
-        .orElseGet(() -> createDefaultCalendar(member));
+        .orElseThrow(() -> new IllegalStateException("캘린더가 존재하지 않습니다."));
 
     return new CalendarSyncStatusResponse(
         calendar.getId(),
@@ -44,14 +141,6 @@ public class CalendarSyncService {
     );
   }
 
-  // 캘린더 생성 로직 -> 혹시 회원 탈퇴나 재가입 시 캘린더 생성 안됐을 때를 대비하여
-  private Calendar createDefaultCalendar(Member member) {
-    Calendar newCalendar = new Calendar();
-    newCalendar.setMember(member);
-    newCalendar.setName("ittaeok");
-    newCalendar.setSynced(false);
-    newCalendar.setSyncedAt(LocalDateTime.now());
-    return calendarRepository.save(newCalendar);
   }
 
-}
+

--- a/src/main/java/com/grepp/spring/app/model/mypage/service/CalendarSyncService.java
+++ b/src/main/java/com/grepp/spring/app/model/mypage/service/CalendarSyncService.java
@@ -1,0 +1,57 @@
+package com.grepp.spring.app.model.mypage.service;
+
+import com.grepp.spring.app.controller.api.mypage.payload.request.SetCalendarSyncRequest;
+import com.grepp.spring.app.controller.api.mypage.payload.response.CalendarSyncStatusResponse;
+import com.grepp.spring.app.model.mainpage.entity.Calendar;
+import com.grepp.spring.app.model.member.entity.Member;
+import com.grepp.spring.app.model.member.repository.MemberRepository;
+import com.grepp.spring.app.model.mypage.repository.CalendarRepository;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CalendarSyncService {
+
+  private final MemberRepository memberRepository;
+  private final CalendarRepository calendarRepository;
+
+  public void updateSyncSetting(String memberId, SetCalendarSyncRequest request) {
+    Member member = memberRepository.findById(memberId)
+        .orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다."));
+
+    Calendar calendar = calendarRepository.findByMember(member)
+        .orElseThrow(() -> new IllegalStateException("캘린더가 존재하지 않습니다."));
+
+    calendar.setSynced(request.isSynced());
+    calendar.setSyncedAt(LocalDateTime.now());
+
+    calendarRepository.save(calendar); // 변경사항 저장
+  }
+
+  public CalendarSyncStatusResponse getCalendarSyncStatus(String memberId) {
+    Member member = memberRepository.findById(memberId)
+        .orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다."));
+
+    Calendar calendar = calendarRepository.findByMember(member)
+        .orElseGet(() -> createDefaultCalendar(member));
+
+    return new CalendarSyncStatusResponse(
+        calendar.getId(),
+        calendar.getName(),
+        calendar.getSynced()
+    );
+  }
+
+  // 캘린더 생성 로직 -> 혹시 회원 탈퇴나 재가입 시 캘린더 생성 안됐을 때를 대비하여
+  private Calendar createDefaultCalendar(Member member) {
+    Calendar newCalendar = new Calendar();
+    newCalendar.setMember(member);
+    newCalendar.setName("ittaeok");
+    newCalendar.setSynced(false);
+    newCalendar.setSyncedAt(LocalDateTime.now());
+    return calendarRepository.save(newCalendar);
+  }
+
+}

--- a/src/main/java/com/grepp/spring/app/model/mypage/service/CalendarSyncService.java
+++ b/src/main/java/com/grepp/spring/app/model/mypage/service/CalendarSyncService.java
@@ -41,7 +41,7 @@ public class CalendarSyncService {
 
   private final RestTemplate restTemplate = new RestTemplate();
 
-  // ✅ 캘린더 동기화 (매번 새로고침 방식)
+  // 캘린더 동기화 (매번 새로고침해서 일정 받아오는 방식)
   public ApiResponse<List<GoogleEventDto>> syncCalendar(String memberId) {
 
     // 1) 회원 조회
@@ -66,7 +66,7 @@ public class CalendarSyncService {
       return ApiResponse.error(ResponseCode.UNAUTHORIZED, googleOAuthService.buildReauthUrl());
     }
 
-    // 4) ✅ 구글 캘린더 API 직접 호출
+    // 4) 구글 캘린더 API 직접 호출
     HttpHeaders headers = new HttpHeaders();
     headers.setBearerAuth(accessToken);
 
@@ -79,7 +79,7 @@ public class CalendarSyncService {
         Map.class
     );
 
-    // 5) ✅ 구글 응답 → DTO 변환
+    // 5) 구글 응답 → DTO 변환
     List<Map<String, Object>> items = (List<Map<String, Object>>) response.getBody().get("items");
     List<GoogleEventDto> events = convertToDto(items);
 
@@ -87,7 +87,7 @@ public class CalendarSyncService {
     return ApiResponse.success(events);
   }
 
-  // ✅ Google JSON → DTO 변환
+  // Google JSON → DTO 변환
   private List<GoogleEventDto> convertToDto(List<Map<String, Object>> items) {
     List<GoogleEventDto> events = new ArrayList<>();
 
@@ -126,20 +126,20 @@ public class CalendarSyncService {
   }
 
 
-  // ✅ 연동 상태 조회 (원하면 유지)
-  public CalendarSyncStatusResponse getCalendarSyncStatus(String memberId) {
-    Member member = memberRepository.findById(memberId)
-        .orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다."));
-
-    Calendar calendar = calendarRepository.findByMember(member)
-        .orElseThrow(() -> new IllegalStateException("캘린더가 존재하지 않습니다."));
-
-    return new CalendarSyncStatusResponse(
-        calendar.getId(),
-        calendar.getName(),
-        calendar.getSynced()
-    );
-  }
+//  // 연동 상태 조회 (원하면 유지) -> 마지막 새로고침 시간 보여줄 거임?
+//  public CalendarSyncStatusResponse getCalendarSyncStatus(String memberId) {
+//    Member member = memberRepository.findById(memberId)
+//        .orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다."));
+//
+//    Calendar calendar = calendarRepository.findByMember(member)
+//        .orElseThrow(() -> new IllegalStateException("캘린더가 존재하지 않습니다."));
+//
+//    return new CalendarSyncStatusResponse(
+//        calendar.getId(),
+//        calendar.getName(),
+//        calendar.getSynced()
+//    );
+//  }
 
   }
 

--- a/src/main/java/com/grepp/spring/app/model/mypage/service/GoogleOAuthService.java
+++ b/src/main/java/com/grepp/spring/app/model/mypage/service/GoogleOAuthService.java
@@ -1,0 +1,95 @@
+package com.grepp.spring.app.model.mypage.service;
+
+import com.grepp.spring.app.controller.api.mypage.payload.response.GoogleTokenResponse;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Service
+@RequiredArgsConstructor
+public class GoogleOAuthService {
+
+  @Value("${google.calendar.client-id}")
+  private String clientId;
+
+  @Value("${google.calendar.client-secret}")
+  private String clientSecret;
+
+  @Value("${google.calendar.redirect-uri}")
+  private String redirectUri;
+
+  private final RestTemplate restTemplate = new RestTemplate();
+
+
+   // 구글 OAuth 최초 연동/재인증 URL 생성
+
+  public String buildReauthUrl() {
+    return UriComponentsBuilder.fromUri(URI.create("https://accounts.google.com/o/oauth2/v2/auth"))
+        .queryParam("client_id", clientId)
+        .queryParam("redirect_uri", redirectUri)
+        .queryParam("response_type", "code")
+        .queryParam("scope", "https://www.googleapis.com/auth/calendar.readonly")
+        .queryParam("access_type", "offline")   // refresh_token 받기 위해 필요
+        .queryParam("prompt", "consent")        // 매번 refresh_token 강제 발급하려면 필요
+        .build()
+        .toUriString();
+  }
+
+
+   // ✅ 최초 연동 시: authorization_code → access_token + refresh_token 교환
+
+  public GoogleTokenResponse exchangeCodeForToken(String code) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+    MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+    params.add("code", code);
+    params.add("client_id", clientId);
+    params.add("client_secret", clientSecret);
+    params.add("redirect_uri", redirectUri);
+    params.add("grant_type", "authorization_code");
+
+    HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+
+    ResponseEntity<GoogleTokenResponse> response = restTemplate.postForEntity(
+        "https://oauth2.googleapis.com/token",
+        request,
+        GoogleTokenResponse.class
+    );
+
+    return response.getBody(); // ✅ 여기엔 access_token + refresh_token 둘 다 옴
+  }
+
+
+   // ✅ 기존 refresh_token으로 새 access_token만 재발급
+
+  public GoogleTokenResponse refreshAccessToken(String refreshToken) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+    MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+    params.add("client_id", clientId);
+    params.add("client_secret", clientSecret);
+    params.add("refresh_token", refreshToken);
+    params.add("grant_type", "refresh_token");
+
+    HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+
+    ResponseEntity<GoogleTokenResponse> response = restTemplate.postForEntity(
+        "https://oauth2.googleapis.com/token",
+        request,
+        GoogleTokenResponse.class
+    );
+
+    return response.getBody(); // ✅ 여기엔 refresh_token은 안 내려오고 access_token만 옴
+  }
+}

--- a/src/main/java/com/grepp/spring/app/model/mypage/service/MypageService.java
+++ b/src/main/java/com/grepp/spring/app/model/mypage/service/MypageService.java
@@ -93,7 +93,7 @@ public class MypageService {
       throw new IllegalArgumentException("요청 정보가 없습니다.");
     }
 
-    String[] days = {"mon", "tue", "wed", "thu", "fri", "sat", "sun"};
+    String[] days = {"MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN"};
     List<FavoriteTimetableDto> resultList = new ArrayList<>();
 
     for (String day : days) {
@@ -101,7 +101,7 @@ public class MypageService {
       if (newBitHex == null || newBitHex.trim().isEmpty()) continue;
 
       Long newBitLong = Long.parseUnsignedLong(newBitHex, 16);
-      Optional<FavoriteTimetable> existing = myTimetableRepository.findByMemberIdAndDay(memberId, day);
+      Optional<FavoriteTimetable> existing = myTimetableRepository.findByMemberIdAndDay(memberId, day.toUpperCase());
 
       if (existing.isPresent()) {
         FavoriteTimetable schedule = existing.get();
@@ -115,7 +115,7 @@ public class MypageService {
           resultList.add(FavoriteTimetableDto.fromEntity(schedule));
         }
       } else {
-        FavoriteTimetable newSchedule = FavoriteTimetable.of(member, day, newBitLong);
+        FavoriteTimetable newSchedule = FavoriteTimetable.of(member, day.toUpperCase(), newBitLong);
         myTimetableRepository.save(newSchedule);
         resultList.add(FavoriteTimetableDto.fromEntity(newSchedule));
       }
@@ -134,13 +134,13 @@ public class MypageService {
 
   private String getTimeBitByDay(CreateFavoriteTimeRequest req, String day) {
     return switch (day) {
-      case "mon" -> req.getTimeBitMon();
-      case "tue" -> req.getTimeBitTue();
-      case "wed" -> req.getTimeBitWed();
-      case "thu" -> req.getTimeBitThu();
-      case "fri" -> req.getTimeBitFri();
-      case "sat" -> req.getTimeBitSat();
-      case "sun" -> req.getTimeBitSun();
+      case "MON" -> req.getTimeBitMon();
+      case "TUE" -> req.getTimeBitTue();
+      case "WED" -> req.getTimeBitWed();
+      case "THU" -> req.getTimeBitThu();
+      case "FRI" -> req.getTimeBitFri();
+      case "SAT" -> req.getTimeBitSat();
+      case "SUN" -> req.getTimeBitSun();
       default -> null;
     };
   }

--- a/src/main/java/com/grepp/spring/app/model/mypage/service/SocialAuthTokenService.java
+++ b/src/main/java/com/grepp/spring/app/model/mypage/service/SocialAuthTokenService.java
@@ -10,27 +10,60 @@ import com.grepp.spring.app.model.member.repository.SocialAuthTokenRepository;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
 
 @Service
 @RequiredArgsConstructor
 public class SocialAuthTokenService {
 
-  private final MemberRepository memberRepository;
   private final SocialAuthTokenRepository socialAuthTokenRepository;
+  private final GoogleOAuthService googleOAuthService;
 
-  public void saveGoogleToken(GoogleTokenResponse tokenResponse, String memberId) {
-    Member member = memberRepository.findById(memberId)
-        .orElseThrow(() -> new IllegalArgumentException("해당 사용자가 존재하지 않습니다."));
 
-    SocialAuthToken token = new SocialAuthToken();
+   // 최초 연동 시 토큰 저장 (있으면 업데이트)
+
+  public void saveGoogleToken(Member member, GoogleTokenResponse tokenResponse) {
+    SocialAuthToken token = socialAuthTokenRepository.findByMember(member)
+        .orElse(new SocialAuthToken());
+
+    token.setMember(member);
     token.setAccessToken(tokenResponse.getAccessToken());
     token.setRefreshToken(tokenResponse.getRefreshToken());
     token.setTokenType(tokenResponse.getTokenType());
     token.setExpiresAt(LocalDateTime.now().plusSeconds(tokenResponse.getExpiresIn()));
     token.setProvider(Provider.GOOGLE);
-    token.setMember(member);
 
     socialAuthTokenRepository.save(token);
   }
 
+
+   // - refresh_token으로 유효한 access_token 확보
+   // - access_token 만료되면 refresh_token으로 재발급
+   // - refresh_token 무효 → null 반환
+
+  public String getValidAccessToken(SocialAuthToken token) {
+    // 아직 access_token이 유효하면 그대로 반환
+    if (token.getExpiresAt().isAfter(LocalDateTime.now())) {
+      return token.getAccessToken();
+    }
+
+    try {
+      // refresh_token으로 새 access_token 발급
+      GoogleTokenResponse newToken = googleOAuthService.refreshAccessToken(token.getRefreshToken());
+      if (newToken == null || newToken.getAccessToken() == null) {
+        return null; // refresh_token 무효 → 재인증 필요
+      }
+
+      // DB 업데이트
+      token.setAccessToken(newToken.getAccessToken());
+      token.setExpiresAt(LocalDateTime.now().plusSeconds(newToken.getExpiresIn()));
+      socialAuthTokenRepository.save(token);
+
+      return newToken.getAccessToken();
+    } catch (HttpClientErrorException e) {
+      return null; // refresh_token도 만료 → 재인증 필요
+    }
+  }
 }
+
+

--- a/src/main/java/com/grepp/spring/app/model/mypage/service/SocialAuthTokenService.java
+++ b/src/main/java/com/grepp/spring/app/model/mypage/service/SocialAuthTokenService.java
@@ -1,0 +1,36 @@
+package com.grepp.spring.app.model.mypage.service;
+
+
+import com.grepp.spring.app.controller.api.auth.Provider;
+import com.grepp.spring.app.controller.api.mypage.payload.response.GoogleTokenResponse;
+import com.grepp.spring.app.model.member.entity.Member;
+import com.grepp.spring.app.model.member.entity.SocialAuthToken;
+import com.grepp.spring.app.model.member.repository.MemberRepository;
+import com.grepp.spring.app.model.member.repository.SocialAuthTokenRepository;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SocialAuthTokenService {
+
+  private final MemberRepository memberRepository;
+  private final SocialAuthTokenRepository socialAuthTokenRepository;
+
+  public void saveGoogleToken(GoogleTokenResponse tokenResponse, String memberId) {
+    Member member = memberRepository.findById(memberId)
+        .orElseThrow(() -> new IllegalArgumentException("해당 사용자가 존재하지 않습니다."));
+
+    SocialAuthToken token = new SocialAuthToken();
+    token.setAccessToken(tokenResponse.getAccessToken());
+    token.setRefreshToken(tokenResponse.getRefreshToken());
+    token.setTokenType(tokenResponse.getTokenType());
+    token.setExpiresAt(LocalDateTime.now().plusSeconds(tokenResponse.getExpiresIn()));
+    token.setProvider(Provider.GOOGLE);
+    token.setMember(member);
+
+    socialAuthTokenRepository.save(token);
+  }
+
+}


### PR DESCRIPTION

## ✅ 관련 이슈
- close #51 

## 🛠️ 작업 내용

- [엔티티 수정]
   - SocialAuthToken: provider string -> enum 타입으로 통일
   - Calendar: 기존 lastSyncedAt 필드명 -> syncUpdatedAt (의미 명확화)
   
- AuthService: 신규 유저 회원가입 시 기본 캘린더 자동 생성 로직 추가
- 구글 캘린더 OAuth 최초 인증 후 refresh token 저장, 이후 수동 새로고침 방식 적용


## 📸 스크린샷 (선택)
- 회원 최초 로그인 시 캘린더 생성
<img width="757" height="128" alt="image" src="https://github.com/user-attachments/assets/95444512-1cae-4143-b72d-a5d2cdb7a02b" />

- 캘린더 연동을 위해 OAuth 인증 성공 시
<img width="688" height="206" alt="image" src="https://github.com/user-attachments/assets/d421cf11-cc79-4eb8-a06f-d86922de65c9" />

- 새로고침 post 요청 시
<img width="2325" height="1462" alt="image" src="https://github.com/user-attachments/assets/596f0cdc-cdc4-4e83-8b24-e58b359058f3" />

구글 캘린더에 일정 추가 후 새로고침 요청 시 새로 추가된 데이터가 보여짐.


## 🧩 기타 참고사항
`캘린더 일정 조회 기능`은 다음 PR에서 작업 예정입니다.
현재는 수동 새로고침 방식인데 추후에 스케줄러 도입해서 자동 동기화 기능 고려해보겠습니다.
또, 지금은 구글 API에서 가져온 일정을 GoogleEventDto 로 바로 반환하는 방식인데
다음 일정 조회 기능에서 CalendarDetail 엔티티에 저장해서 통합 일정을 보여줄 수 있게 수정할 예정입니다.
