### PR TITLE
그룹 탈퇴 기능 구현

### DIFF
--- a/src/main/java/com/grepp/spring/app/controller/api/group/GroupController.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/group/GroupController.java
@@ -268,21 +268,10 @@ public class GroupController {
     public ResponseEntity<ApiResponse<WithdrawGroupResponse>> withdrawGroup(
         @PathVariable Long id
     ) {
-        try {
-            // 그룹 탈퇴
-            groupCommandWithdrawService.withdrawGroup(id);
-            // 그룹 탈퇴 성공
-            return ResponseEntity.ok(ApiResponse.success("그룹에서 탈퇴하였습니다."));
-        } catch (Exception e) {
-            // 권한 없음: 403
-            if (e instanceof AuthApiException) {
-                return ResponseEntity.status(401)
-                    .body(ApiResponse.error(ResponseCode.UNAUTHORIZED, "권한이 없습니다."));
-            }
-            // 잘못된 요청: 400
-            return ResponseEntity.status(400)
-                .body(ApiResponse.error(ResponseCode.BAD_REQUEST, "서버가 요청을 처리할 수 없습니다."));
-        }
+        // 그룹 탈퇴
+        groupCommandWithdrawService.withdrawGroup(id);
+        // 그룹 탈퇴 성공
+        return ResponseEntity.ok(ApiResponse.success("그룹에서 탈퇴하였습니다."));
     }
 
 }

--- a/src/main/java/com/grepp/spring/app/model/event/repository/EventMemberRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/event/repository/EventMemberRepository.java
@@ -18,7 +18,7 @@ public interface EventMemberRepository extends JpaRepository<EventMember, Long> 
 
     List<EventMember> findAllByEventIdAndActivatedTrue(Long eventId);
 
-    void delete(Event event, String id);
-
     ArrayList<EventMember> findByEvent(Event event);
+
+    void deleteByEventAndMemberId(Event event, String id);
 }

--- a/src/main/java/com/grepp/spring/app/model/event/repository/EventMemberRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/event/repository/EventMemberRepository.java
@@ -1,6 +1,8 @@
 package com.grepp.spring.app.model.event.repository;
 
+import com.grepp.spring.app.model.event.entity.Event;
 import com.grepp.spring.app.model.event.entity.EventMember;
+import java.util.ArrayList;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -16,4 +18,7 @@ public interface EventMemberRepository extends JpaRepository<EventMember, Long> 
 
     List<EventMember> findAllByEventIdAndActivatedTrue(Long eventId);
 
+    void delete(Event event, String id);
+
+    ArrayList<EventMember> findByEvent(Event event);
 }

--- a/src/main/java/com/grepp/spring/app/model/event/repository/EventRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/event/repository/EventRepository.java
@@ -1,6 +1,7 @@
 package com.grepp.spring.app.model.event.repository;
 
 import com.grepp.spring.app.model.event.entity.Event;
+import java.util.ArrayList;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,4 +10,5 @@ import org.springframework.stereotype.Repository;
 public interface EventRepository extends JpaRepository<Event, Long> {
 
 
+    ArrayList<Event> findByGroupId(Long groupId);
 }

--- a/src/main/java/com/grepp/spring/app/model/group/repository/GroupMemberCommandRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/group/repository/GroupMemberCommandRepository.java
@@ -1,9 +1,12 @@
 package com.grepp.spring.app.model.group.repository;
 
+import com.grepp.spring.app.model.group.entity.Group;
 import com.grepp.spring.app.model.group.entity.GroupMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface GroupMemberCommandRepository extends JpaRepository<GroupMember, Long> {
 
     void deleteByGroupId(Long groupId);
+
+    void delete(Group group, String id);
 }

--- a/src/main/java/com/grepp/spring/app/model/group/repository/GroupMemberCommandRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/group/repository/GroupMemberCommandRepository.java
@@ -8,5 +8,5 @@ public interface GroupMemberCommandRepository extends JpaRepository<GroupMember,
 
     void deleteByGroupId(Long groupId);
 
-    void delete(Group group, String id);
+    void deleteByGroupAndMemberId(Group group, String id);
 }

--- a/src/main/java/com/grepp/spring/app/model/group/repository/GroupMemberQueryRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/group/repository/GroupMemberQueryRepository.java
@@ -1,8 +1,10 @@
 package com.grepp.spring.app.model.group.repository;
 
+import com.grepp.spring.app.model.group.code.GroupRole;
 import com.grepp.spring.app.model.group.entity.Group;
 import com.grepp.spring.app.model.group.entity.GroupMember;
 import com.grepp.spring.app.model.member.entity.Member;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
@@ -20,4 +22,8 @@ public interface GroupMemberQueryRepository extends JpaRepository<GroupMember, L
     List<GroupMember> findByGroupIdIn(List<Long> groupIds);
 
     List<GroupMember> findByGroup(Group group);
+
+    ArrayList<GroupMember> findByGroupAndRole(Group group, GroupRole role);
+
+    ArrayList<GroupMember> findByGroupAndMember(Group group, Member member);
 }

--- a/src/main/java/com/grepp/spring/app/model/group/service/GroupCommandWithdrawService.java
+++ b/src/main/java/com/grepp/spring/app/model/group/service/GroupCommandWithdrawService.java
@@ -98,23 +98,23 @@ public class GroupCommandWithdrawService {
 
         // 삭제 진행
         // groupMember 삭제
-        groupMemberCommandRepository.delete(group, member.getId());
+        groupMemberCommandRepository.deleteByGroupAndMemberId(group, member.getId());
         // 그룹 내 이벤트에 대한 처리
         for(Event event: eventRepository.findByGroupId(groupId)){
             // eventMember 삭제
-            eventMemberRepository.delete(event, member.getId());
+            eventMemberRepository.deleteByEventAndMemberId(event, member.getId());
             // 이벤트 내 일정에 대한 처리
-            for(Schedule schedule: scheduleQueryRepository.findByEnvet(event)){
+            for(Schedule schedule: scheduleQueryRepository.findByEvent(event)){
                 // scheduleMember 삭제
                 // 일정에 본인이 일정 팀장인 경우 isRoleMaster를 true로 설정
                 boolean isRoleMaster = false;
                 if(scheduleMemberQueryRepository
-                    .findByEventAndMemberId(event, member.getId())
+                    .findByScheduleAndMemberId(schedule, member.getId())
                     .getRole()
                     .equals(ScheduleRole.ROLE_MASTER)){
                     isRoleMaster = true;
                 }
-                scheduleMemberCommandRepository.delete(schedule, member.getId());
+                scheduleMemberCommandRepository.deleteByScheduleAndMemberId(schedule, member.getId());
                 // 일정에 본인만 포함된 경우 -> schedule 삭제
                 if(scheduleMemberQueryRepository.findBySchedule(schedule).isEmpty()){
                     scheduleCommandRepository.delete(schedule);

--- a/src/main/java/com/grepp/spring/app/model/group/service/GroupCommandWithdrawService.java
+++ b/src/main/java/com/grepp/spring/app/model/group/service/GroupCommandWithdrawService.java
@@ -1,10 +1,37 @@
 package com.grepp.spring.app.model.group.service;
 
+import com.grepp.spring.app.model.auth.domain.Principal;
+import com.grepp.spring.app.model.event.entity.Event;
+import com.grepp.spring.app.model.event.repository.EventMemberRepository;
+import com.grepp.spring.app.model.event.repository.EventRepository;
+import com.grepp.spring.app.model.group.code.GroupRole;
+import com.grepp.spring.app.model.group.entity.Group;
+import com.grepp.spring.app.model.group.entity.GroupMember;
 import com.grepp.spring.app.model.group.repository.GroupCommandRepository;
+import com.grepp.spring.app.model.group.repository.GroupMemberCommandRepository;
+import com.grepp.spring.app.model.group.repository.GroupMemberQueryRepository;
 import com.grepp.spring.app.model.group.repository.GroupQueryRepository;
+import com.grepp.spring.app.model.member.entity.Member;
+import com.grepp.spring.app.model.member.repository.MemberRepository;
+import com.grepp.spring.app.model.schedule.code.ScheduleRole;
+import com.grepp.spring.app.model.schedule.entity.Schedule;
+import com.grepp.spring.app.model.schedule.entity.ScheduleMember;
+import com.grepp.spring.app.model.schedule.repository.ScheduleCommandRepository;
+import com.grepp.spring.app.model.schedule.repository.ScheduleMemberCommandRepository;
+import com.grepp.spring.app.model.schedule.repository.ScheduleMemberQueryRepository;
+import com.grepp.spring.app.model.schedule.repository.ScheduleQueryRepository;
+import com.grepp.spring.infra.error.exceptions.group.GroupNotFoundException;
+import com.grepp.spring.infra.error.exceptions.group.NotGroupUserException;
+import com.grepp.spring.infra.error.exceptions.group.OnlyOneGroupLeaderException;
+import com.grepp.spring.infra.response.GroupErrorCode;
+import java.util.ArrayList;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Slf4j
@@ -13,13 +40,103 @@ public class GroupCommandWithdrawService {
 
     private final GroupCommandRepository groupCommandRepository;
     private final GroupQueryRepository groupQueryRepository;
+    private final MemberRepository memberRepository;
+    private final GroupMemberQueryRepository groupMemberQueryRepository;
+    private final EventRepository eventRepository;
+    private final ScheduleCommandRepository scheduleCommandRepository;
+    private final ScheduleQueryRepository scheduleQueryRepository;
+    private final ScheduleMemberQueryRepository scheduleMemberQueryRepository;
+    private final GroupMemberCommandRepository groupMemberCommandRepository;
+    private final EventMemberRepository eventMemberRepository;
+    private final ScheduleMemberCommandRepository scheduleMemberCommandRepository;
 
     // 그룹 탈퇴
+    @Transactional
     public void withdrawGroup(Long groupId){
+        // http 요청 사용자 조회
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Principal user = (Principal) authentication.getPrincipal();
+        Member member = memberRepository.findById(user.getUsername()).orElseThrow();
+        // TODO: member가 없다면 throw 예외(회원이 아닙니다: 401)
 
+        Optional<Group> groupOptional = groupQueryRepository.findById(groupId);
+        // 예외 발생: 해당 group은 존재하지 않음 - 404 GROUP_NOT_FOUND
+        if(groupOptional.isEmpty()){
+            throw new GroupNotFoundException(GroupErrorCode.GROUP_NOT_FOUND);
+        }
+        Group group = groupOptional.get();
+
+        Optional<GroupMember> groupMemberOptional = groupMemberQueryRepository.findByGroupIdAndMemberId(groupId,
+            member.getId());
+        // 예외 발생: http 메서드를 요청한 유저가 해당 그룹의 그룹원이 아님 - 403 NOT_GROUP_MEMBER
+        if(groupMemberOptional.isEmpty()){
+            throw new NotGroupUserException(GroupErrorCode.NOT_GROUP_MEMBER);
+        }
+        GroupMember groupMember = groupMemberOptional.get();
+
+        // 해당 그룹의 리더들 조회
+        ArrayList<GroupMember> groupLeaders = groupMemberQueryRepository.findByGroupAndRole(group, GroupRole.GROUP_LEADER);
+        ArrayList<GroupMember> groupMembers = groupMemberQueryRepository.findByGroupAndRole(group, GroupRole.GROUP_MEMBER);
+        // 예외 발생: 해당 그룹의 리더가 1명이고 그룹원이 있는 경우 - 409 ONLY_ONE_LEADER
+        if(groupMember.getRole().equals(GroupRole.GROUP_LEADER)
+            && groupLeaders.size()==1
+            && !groupMembers.isEmpty()){
+            throw new OnlyOneGroupLeaderException(GroupErrorCode.ONE_GROUP_LEADER);
+        }
+
+        // 해당 그룹의 슈퍼 리더 이면서 그룹 내에 리더가 여러 명일 경우 -> 슈퍼 리더를 랜덤하게 타 groupLeader에게 이양
+        if(groupMember.getRole().equals(GroupRole.GROUP_LEADER)
+            && groupMember.getGroupAdmin()
+            && groupLeaders.size()>1){
+            // 그룹 슈러 리더 한 번 전달 후 반복문 탈출
+            for(GroupMember groupLeader1: groupLeaders){
+                if(groupLeader1.equals(groupMember)) continue;
+                groupLeader1.setGroupAdmin(true);
+                break;
+            }
+        }
+
+        // 삭제 진행
+        // groupMember 삭제
+        groupMemberCommandRepository.delete(group, member.getId());
+        // 그룹 내 이벤트에 대한 처리
+        for(Event event: eventRepository.findByGroupId(groupId)){
+            // eventMember 삭제
+            eventMemberRepository.delete(event, member.getId());
+            // 이벤트 내 일정에 대한 처리
+            for(Schedule schedule: scheduleQueryRepository.findByEnvet(event)){
+                // scheduleMember 삭제
+                // 일정에 본인이 일정 팀장인 경우 isRoleMaster를 true로 설정
+                boolean isRoleMaster = false;
+                if(scheduleMemberQueryRepository
+                    .findByEventAndMemberId(event, member.getId())
+                    .getRole()
+                    .equals(ScheduleRole.ROLE_MASTER)){
+                    isRoleMaster = true;
+                }
+                scheduleMemberCommandRepository.delete(schedule, member.getId());
+                // 일정에 본인만 포함된 경우 -> schedule 삭제
+                if(scheduleMemberQueryRepository.findBySchedule(schedule).isEmpty()){
+                    scheduleCommandRepository.delete(schedule);
+                }
+                // 일정에 본인이 일정 팀장인 경우 -> 팀장 권한 랜덤으로 넘기기
+                else if (isRoleMaster) {
+                    ArrayList<ScheduleMember> scheduleMembers = scheduleMemberQueryRepository.findBySchedule(schedule);
+                    // 일정 팀장 권한 한 번 전달 후 반복문 탈출
+                    for(ScheduleMember scheduleMember1: scheduleMembers){
+                        scheduleMember1.setRole(ScheduleRole.ROLE_MASTER);
+                        break;
+                    }
+                }
+            }
+            // 이벤트에 본인만 포함된 경우 -> Event 삭제
+            if(eventMemberRepository.findByEvent(event).isEmpty()){
+                eventRepository.delete(event);
+            }
+        }
+        // 그룹에 본인만 포함된 경우 -> group 삭제
+        if(groupMemberQueryRepository.findByGroup(group).isEmpty()){
+            groupCommandRepository.delete(group);
+        }
     }
-    // TODO : 예외처리
-    // groupId가 db에 없다면 404_GROUP_NOT_FOUND
-    // 현재 유저가 해당 일정의 구성원이 아니면 403_NOT_SCHEDULE_MEMBER
-
 }

--- a/src/main/java/com/grepp/spring/app/model/schedule/repository/ScheduleMemberCommandRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/schedule/repository/ScheduleMemberCommandRepository.java
@@ -13,5 +13,5 @@ public interface ScheduleMemberCommandRepository extends JpaRepository<ScheduleM
     @Query("DELETE from ScheduleMember sm where sm.schedule.id = :scheduleId")
     void deleteAllByScheduleId(@Param("scheduleId") Long scheduleId);
 
-    void delete(Schedule schedule, String memberId);
+    void deleteByScheduleAndMemberId(Schedule schedule, String id);
 }

--- a/src/main/java/com/grepp/spring/app/model/schedule/repository/ScheduleMemberCommandRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/schedule/repository/ScheduleMemberCommandRepository.java
@@ -1,5 +1,6 @@
 package com.grepp.spring.app.model.schedule.repository;
 
+import com.grepp.spring.app.model.schedule.entity.Schedule;
 import com.grepp.spring.app.model.schedule.entity.ScheduleMember;
 import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,4 +12,6 @@ public interface ScheduleMemberCommandRepository extends JpaRepository<ScheduleM
     @Modifying
     @Query("DELETE from ScheduleMember sm where sm.schedule.id = :scheduleId")
     void deleteAllByScheduleId(@Param("scheduleId") Long scheduleId);
+
+    void delete(Schedule schedule, String memberId);
 }

--- a/src/main/java/com/grepp/spring/app/model/schedule/repository/ScheduleMemberQueryRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/schedule/repository/ScheduleMemberQueryRepository.java
@@ -1,7 +1,11 @@
 package com.grepp.spring.app.model.schedule.repository;
 
+import com.grepp.spring.app.model.event.entity.Event;
+import com.grepp.spring.app.model.member.entity.Member;
+import com.grepp.spring.app.model.schedule.entity.Schedule;
 import com.grepp.spring.app.model.schedule.entity.ScheduleMember;
 import io.lettuce.core.dynamic.annotation.Param;
+import java.util.ArrayList;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -17,4 +21,8 @@ public interface ScheduleMemberQueryRepository extends JpaRepository<ScheduleMem
     @Query("select sm from ScheduleMember sm where sm.member.id = :memberId and sm.schedule.id = :scheduleId")
     ScheduleMember findScheduleMember(@Param("memberId") String memberId, @Param("scheduleId") Long scheduleId);
 
+    ScheduleMember findByEventAndMemberId(Event event, String memberId);
+
+
+    ArrayList<ScheduleMember> findBySchedule(Schedule schedule);
 }

--- a/src/main/java/com/grepp/spring/app/model/schedule/repository/ScheduleMemberQueryRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/schedule/repository/ScheduleMemberQueryRepository.java
@@ -7,6 +7,7 @@ import com.grepp.spring.app.model.schedule.entity.ScheduleMember;
 import io.lettuce.core.dynamic.annotation.Param;
 import java.util.ArrayList;
 import java.util.List;
+import javax.management.relation.Relation;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -21,8 +22,7 @@ public interface ScheduleMemberQueryRepository extends JpaRepository<ScheduleMem
     @Query("select sm from ScheduleMember sm where sm.member.id = :memberId and sm.schedule.id = :scheduleId")
     ScheduleMember findScheduleMember(@Param("memberId") String memberId, @Param("scheduleId") Long scheduleId);
 
-    ScheduleMember findByEventAndMemberId(Event event, String memberId);
-
-
     ArrayList<ScheduleMember> findBySchedule(Schedule schedule);
+
+    ScheduleMember findByScheduleAndMemberId(Schedule schedule, String id);
 }

--- a/src/main/java/com/grepp/spring/app/model/schedule/repository/ScheduleQueryRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/schedule/repository/ScheduleQueryRepository.java
@@ -11,5 +11,6 @@ public interface ScheduleQueryRepository extends JpaRepository<Schedule, Long> {
 
     List<Schedule> findByEventIdAndStatusInAndActivatedTrue(Long eventId, List<ScheduleStatus> list);
 
-    List<Schedule> findByEnvet(Event event);
+
+    List<Schedule> findByEvent(Event event);
 }

--- a/src/main/java/com/grepp/spring/app/model/schedule/repository/ScheduleQueryRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/schedule/repository/ScheduleQueryRepository.java
@@ -1,17 +1,15 @@
 package com.grepp.spring.app.model.schedule.repository;
 
+import com.grepp.spring.app.model.event.entity.Event;
 import com.grepp.spring.app.model.schedule.code.ScheduleStatus;
-import com.grepp.spring.app.model.schedule.entity.MetroTransfer;
 import com.grepp.spring.app.model.schedule.entity.Schedule;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
-import java.util.List;
 
 public interface ScheduleQueryRepository extends JpaRepository<Schedule, Long> {
 
     List<Schedule> findByEventIdAndStatusInAndActivatedTrue(Long eventId, List<ScheduleStatus> list);
 
+    List<Schedule> findByEnvet(Event event);
 }

--- a/src/main/java/com/grepp/spring/infra/error/exceptions/group/OnlyOneGroupLeaderException.java
+++ b/src/main/java/com/grepp/spring/infra/error/exceptions/group/OnlyOneGroupLeaderException.java
@@ -1,0 +1,24 @@
+package com.grepp.spring.infra.error.exceptions.group;
+
+import com.grepp.spring.infra.response.GroupErrorCode;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class OnlyOneGroupLeaderException extends RuntimeException {
+
+    private final GroupErrorCode code;
+
+    public OnlyOneGroupLeaderException(GroupErrorCode code) {
+        this.code = code;
+    }
+
+    public OnlyOneGroupLeaderException(GroupErrorCode code, Exception e) {
+        this.code = code;
+        log.error(e.getMessage(), e);
+    }
+
+    public GroupErrorCode code() {
+        return code;
+    }
+
+}

--- a/src/main/java/com/grepp/spring/infra/error/groupAdvice/GroupExceptionAdvice.java
+++ b/src/main/java/com/grepp/spring/infra/error/groupAdvice/GroupExceptionAdvice.java
@@ -6,6 +6,7 @@ import com.grepp.spring.infra.error.exceptions.group.NotGroupLeaderException;
 import com.grepp.spring.infra.error.exceptions.group.NotGroupUserException;
 import com.grepp.spring.infra.error.exceptions.group.NotScheduleLeaderException;
 import com.grepp.spring.infra.error.exceptions.group.NotScheduleUserException;
+import com.grepp.spring.infra.error.exceptions.group.OnlyOneGroupLeaderException;
 import com.grepp.spring.infra.error.exceptions.group.ScheduleAlreadyInGroupException;
 import com.grepp.spring.infra.error.exceptions.group.ScheduleNotFoundException;
 import com.grepp.spring.infra.error.exceptions.group.UserAlreadyInGroupException;
@@ -106,5 +107,13 @@ public class GroupExceptionAdvice {
 
         return ResponseEntity.status(ResponseCode.NOT_FOUND.status())
             .body(ApiResponse.error(GroupErrorCode.SCHEDULE_ALREADY_IN_GROUP));
+    }
+
+    @ExceptionHandler(OnlyOneGroupLeaderException.class)
+    public ResponseEntity<ApiResponse<String>> onlyOneGroupLeaderExHandler(
+        OnlyOneGroupLeaderException ex){
+
+        return ResponseEntity.status(ResponseCode.NOT_FOUND.status())
+            .body(ApiResponse.error(GroupErrorCode.ONE_GROUP_LEADER));
     }
 }

--- a/src/main/java/com/grepp/spring/infra/response/GroupErrorCode.java
+++ b/src/main/java/com/grepp/spring/infra/response/GroupErrorCode.java
@@ -12,7 +12,8 @@ public enum GroupErrorCode {
     SCHEDULE_NOT_FOUND("404", HttpStatus.NOT_FOUND,"존재하지 않는 일정입니다."),
     USER_NOT_IN_GROUP("404", HttpStatus.NOT_FOUND,"유저가 해당 그룹에 포함되어 있지 않습니다."),
     SCHEDULE_ALREADY_IN_GROUP("409", HttpStatus.CONFLICT,"이미 그룹에 존재한 일정입니다."),
-    USER_ALREADY_IN_GROUP("409", HttpStatus.CONFLICT,"이미 그룹에 존재한 유저입니다.");
+    USER_ALREADY_IN_GROUP("409", HttpStatus.CONFLICT,"이미 그룹에 존재한 유저입니다."),
+    ONE_GROUP_LEADER("409", HttpStatus.CONFLICT,"그룹 내 유일한 그룹장입니다. 그룹원에게 그룹장 권한을 부여해주세요.");
 
 
     private final String code;


### PR DESCRIPTION
## ✅ 관련 이슈
- close #94 

## 🛠️ 작업 내용
- 그룹 탈퇴 시 유일한 leader인 경우 예외 처리
- 그룹 탈퇴 시 슈퍼leader일 경우 타 leader에게 슈퍼leader 전달 처리
- 그룹 탈퇴 시 이벤트, 일정에서도 탈퇴
- 임의의 일정에서 Master인 경우 타 일정 구성원에게 Master 권한 전달
- 그룹 탈퇴 시 유일한 그룹원이나 유일한 이벤트원이나 유일한 일정 구성원일 경우 그룹, 이벤트, 일정 삭제

## 📸 스크린샷 (선택)
- <img width="1315" height="741" alt="image" src="https://github.com/user-attachments/assets/32c74541-3e65-4a81-ae49-f704a831b804" />

## 🧩 기타 참고사항
- 권한을 옮길 때 랜덤은 아니고 조회 후 최초로 조회되는 경우의 멤버에게 전달(본인 제외)
- 추후 patch가 아닌 delete 메서드로 수정해야 함