### PR TITLE
✨ feat	일회성 일정을 그룹에 편입 기능 구현

### DIFF
--- a/src/main/java/com/grepp/spring/app/controller/api/group/GroupController.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/group/GroupController.java
@@ -238,21 +238,9 @@ public class GroupController {
     public ResponseEntity<ApiResponse<ScheduleToGroupResponse>> moveScheduleToGroup(
         @RequestBody ScheduleToGroupRequest request
     ) {
-        try {
-            // 일회성 일정 -> 그룹 일정으로 이동
-            groupCommandGroupTransferService.transferSchedule(request);
-            // 일회성 일정 -> 그룹 일정으로 이동 성공
-            return ResponseEntity.ok(ApiResponse.success("일회성 일정에서 그룹으로 바뀌었습니다."));
-        } catch (Exception e) {
-            // 권한 없음: 403
-            if (e instanceof AuthApiException) {
-                return ResponseEntity.status(401)
-                    .body(ApiResponse.error(ResponseCode.UNAUTHORIZED, "권한이 없습니다."));
-            }
-            // 잘못된 요청: 400
-            return ResponseEntity.status(400)
-                .body(ApiResponse.error(ResponseCode.BAD_REQUEST, "서버가 요청을 처리할 수 없습니다."));
-        }
+        groupCommandGroupTransferService.transferSchedule(request);
+        // 일회성 일정 -> 그룹 일정으로 이동 성공
+        return ResponseEntity.ok(ApiResponse.success("일회성 일정에서 그룹으로 바뀌었습니다."));
     }
 
 

--- a/src/main/java/com/grepp/spring/app/model/group/service/GroupCommandGroupTransferService.java
+++ b/src/main/java/com/grepp/spring/app/model/group/service/GroupCommandGroupTransferService.java
@@ -1,54 +1,111 @@
 package com.grepp.spring.app.model.group.service;
 
 import com.grepp.spring.app.controller.api.group.payload.request.ScheduleToGroupRequest;
+import com.grepp.spring.app.model.auth.domain.Principal;
+import com.grepp.spring.app.model.event.entity.Event;
+import com.grepp.spring.app.model.event.repository.EventRepository;
+import com.grepp.spring.app.model.group.entity.Group;
+import com.grepp.spring.app.model.group.entity.GroupMember;
 import com.grepp.spring.app.model.group.repository.GroupCommandRepository;
+import com.grepp.spring.app.model.group.repository.GroupMemberCommandRepository;
+import com.grepp.spring.app.model.group.repository.GroupMemberQueryRepository;
+import com.grepp.spring.app.model.group.repository.GroupMemberRepository;
 import com.grepp.spring.app.model.group.repository.GroupQueryRepository;
+import com.grepp.spring.app.model.member.entity.Member;
+import com.grepp.spring.app.model.member.repository.MemberRepository;
+import com.grepp.spring.app.model.schedule.entity.Schedule;
+import com.grepp.spring.app.model.schedule.entity.ScheduleMember;
+import com.grepp.spring.app.model.schedule.repository.ScheduleMemberQueryRepository;
+import com.grepp.spring.app.model.schedule.repository.ScheduleQueryRepository;
+import com.grepp.spring.infra.error.exceptions.group.GroupNotFoundException;
+import com.grepp.spring.infra.error.exceptions.group.ScheduleAlreadyInGroupException;
+import com.grepp.spring.infra.error.exceptions.group.ScheduleNotFoundException;
+import com.grepp.spring.infra.error.exceptions.group.UserNotInGroupException;
+import com.grepp.spring.infra.response.GroupErrorCode;
+import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Slf4j
 @RequiredArgsConstructor
 public class GroupCommandGroupTransferService {
+
     private final GroupCommandRepository groupCommandRepository;
     private final GroupQueryRepository groupQueryRepository;
-
+    private final MemberRepository memberRepository;
+    private final ScheduleQueryRepository scheduleQueryRepository;
+    private final ScheduleMemberQueryRepository scheduleMemberQueryRepository;
+    private final GroupMemberRepository groupMemberRepository;
+    private final GroupMemberQueryRepository groupMemberQueryRepository;
+    private final GroupMemberCommandRepository groupMemberCommandRepository;
+    private final EventRepository eventRepository;
 
     // 일회성 일정을 그룹으로 편입
+    @Transactional
     public void transferSchedule(ScheduleToGroupRequest request) {
 
+        // http 요청 사용자 조회
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Principal user = (Principal) authentication.getPrincipal();
+        Member member = memberRepository.findById(user.getUsername()).orElseThrow();
+        // TODO: member가 없다면 throw 예외(회원이 아닙니다: 401)
+
+        Optional<Schedule> scheduleOptional = scheduleQueryRepository.findById(request.getScheduleId());
+        // 예외 발생: 해당 schedule이 db에 없음: 404 SCHEDULE_NOT_FOUND
+        if (scheduleOptional.isEmpty()) {
+            throw new ScheduleNotFoundException(GroupErrorCode.SCHEDULE_NOT_FOUND);
+        }
+
+        Optional<Group> groupOptional = groupQueryRepository.findById(request.getGroupId());
+        // 예외 발생: 해당 group은 존재하지 않음 - 404 GROUP_NOT_FOUND
+        if(groupOptional.isEmpty()){
+            throw new GroupNotFoundException(GroupErrorCode.GROUP_NOT_FOUND);
+        }
+        Group group = groupOptional.get();
+
+        Schedule schedule = scheduleOptional.get();
+        Event event = schedule.getEvent();
+        Group group1 = event.getGroup();
+        // 예외 발생: 일회성 일정이 아님: 409 SCHEDULE_ALREADY_IN_GROUP
+        if (group1.getIsGrouped()) {
+            throw new ScheduleAlreadyInGroupException(GroupErrorCode.SCHEDULE_ALREADY_IN_GROUP);
+        }
+
+        // 조회
+        List<GroupMember> groupMembers = groupMemberQueryRepository.findByGroup(group);
+        List<ScheduleMember> scheduleMembers = scheduleMemberQueryRepository.findByScheduleId(request.getScheduleId());
+        for (ScheduleMember scheduleMember : scheduleMembers) {
+            Member member1 = scheduleMember.getMember();
+            boolean temp = false;
+            for(GroupMember groupMember: groupMembers){
+                if(member1.equals(groupMember.getMember())) {
+                    temp = true;
+                    break;
+                }
+            }
+            // 예외 발생: 해당 그룹으로 편입시킬 수 없음 404 - USER_NOT_IN_GROUP
+            if(!temp){
+                throw new UserNotInGroupException(GroupErrorCode.USER_NOT_IN_GROUP);
+            }
+        }
+
+        // 편입
+        for(GroupMember groupMember: groupMembers) {
+            groupMemberCommandRepository.deleteByGroupAndMemberId(group1, groupMember.getMember().getId());
+        }
+
+
+        event.getGroup().getEvents().remove(event); // 역방향에서도 제거
+        event.setGroup(null);                      // 주인 쪽에서도 제거
+        // 2. 새 group과 연결
+        event.setGroup(group);
+        group.getEvents().add(event);
+        groupCommandRepository.delete(group1);
     }
-    // TODO : 예외처리
-    // id가 db에 없다면 404_GROUP_NOT_FOUND
-    // request의 scheduleId가 이미 그룹에 있다면 409_SCHEDULE_ALREADY_IN_GROUP
-    // request의 scheduleId가 db에 없다면 404_SCHEDULE_NOT_FOUND
-    // 현재 유저가 해당 일정의 구성원이 아니면 403_NOT_SCHEDULE_MEMBER
-    // 현재 유저가 해당 일정의 팀장이 아니면 403_NOT_SCHEDULE_OWNER
-
-
-    //        if(
-    //            request.getGroupId()!=10001L && request.getGroupId()!=10002L && request.getGroupId()!=10003L &&
-    //            request.getGroupId()!=10004L && request.getGroupId()!=10005L &&
-    //            request.getGroupId()!=10006L
-    //            ){
-    //    return ResponseEntity.status(404)
-    //        .body(ApiResponse.error(ResponseCode.NOT_FOUND, "해당 그룹을 찾을 수 없습니다."));
-    //}
-    //            if(
-    //                request.getScheduleId()==30001L || request.getScheduleId()==30002L || request.getScheduleId()==30003L ||
-    //                request.getScheduleId()==30004L || request.getScheduleId()==30005L ||
-    //                request.getScheduleId()==31111L || request.getScheduleId()==32222L || request.getScheduleId()==33333L || request.getScheduleId()==34444L
-    //                ){
-    //    return ResponseEntity.status(409)
-    //        .body(ApiResponse.error(ResponseCode.CONFLICT_REGISTER, "이미 그룹에 존재하는 일정 입니다."));
-    //}
-    //            else if(
-    //                request.getScheduleId()!=35555L && request.getScheduleId()!=36666L && request.getScheduleId()!=37777L &&
-    //                request.getScheduleId()!=38888L && request.getScheduleId()!=39999L
-    //                ){
-    //    return ResponseEntity.status(404)
-    //        .body(ApiResponse.error(ResponseCode.NOT_FOUND, "해당 일정을 찾을 수 없습니다."));
-    //}
-
 }


### PR DESCRIPTION
✨ feat	일회성 일정을 그룹에 편입 기능 구현

## ✅ 관련 이슈
- close #110

## 🛠️ 작업 내용
- 일회성 일정을 그룹에 편입
- 일정의 구성원들이 편입하려는 그룹에 모두 포함되어야 함
- 편입 후엔 해당 일정 및 이벤트는 그룹에 포함되고, 기존의 groupMember는 제거
-                                                                                       eventMember와 scheduleMember는 유지

## 📸 스크린샷 (선택)
<img width="1125" height="260" alt="image" src="https://github.com/user-attachments/assets/da9fe700-11b8-4556-8253-9bb5390d4d92" />
편입 전 이벤트

<img width="1384" height="437" alt="image" src="https://github.com/user-attachments/assets/8af1f282-7738-48ee-8c4a-f21aed913458" />
편입

<img width="1133" height="241" alt="image" src="https://github.com/user-attachments/assets/5bd6d6a8-3e28-4e4e-bc3c-84e341ad4ed8" />
편입 후 이벤트

## 🧩 기타 참고사항
- 편입 후 기존에 있던 임의의 일회성 그룹도 삭제됨
