### PR TITLE
♻️ refactor : api 수정

### DIFF
--- a/src/main/java/com/grepp/spring/app/controller/api/schedules/ScheduleController.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/schedules/ScheduleController.java
@@ -82,9 +82,9 @@ public class ScheduleController {
                         "해당 이벤트를 찾을 수 없습니다. eventId를 확인해주세요."));
             }
 
-            scheduleCommandService.createSchedule(request);
+            CreateSchedulesResponse response = scheduleCommandService.createSchedule(request);
 
-            return ResponseEntity.ok(ApiResponse.success("일정이 등록되었습니다."));
+            return ResponseEntity.ok(ApiResponse.success(response));
         }
          catch (Exception e) {
 

--- a/src/main/java/com/grepp/spring/app/controller/api/schedules/payload/response/CreateSchedulesResponse.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/schedules/payload/response/CreateSchedulesResponse.java
@@ -1,10 +1,16 @@
 package com.grepp.spring.app.controller.api.schedules.payload.response;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class CreateSchedulesResponse {
-
+    private Long scheduleId;
 }

--- a/src/main/java/com/grepp/spring/app/model/schedule/code/MeetingPlatform.java
+++ b/src/main/java/com/grepp/spring/app/model/schedule/code/MeetingPlatform.java
@@ -1,7 +1,9 @@
 package com.grepp.spring.app.model.schedule.code;
 
 public enum MeetingPlatform {
-    GOOGLE_MEET,
-    ZOOM,
-    NONE
+
+    GOOGLE_MEET, ZOOM, NONE,
+
+    // 추가
+    DISCORD, ZEP,
 }

--- a/src/main/java/com/grepp/spring/app/model/schedule/code/WorkspaceType.java
+++ b/src/main/java/com/grepp/spring/app/model/schedule/code/WorkspaceType.java
@@ -1,5 +1,9 @@
 package com.grepp.spring.app.model.schedule.code;
 
 public enum WorkspaceType {
-    ZEP, DISCORD, FIGMA, GOOGLE_DOS, MIRO, CANVA
+//    ZEP, DISCORD, GOOGLE_DOS
+    FIGMA, MIRO, CANVA,
+
+    // 추가 , 변경
+    GITHUB, GOOGLE_DOCS, NOTION
 }

--- a/src/main/java/com/grepp/spring/app/model/schedule/dto/CreateScheduleDto.java
+++ b/src/main/java/com/grepp/spring/app/model/schedule/dto/CreateScheduleDto.java
@@ -1,6 +1,7 @@
 package com.grepp.spring.app.model.schedule.dto;
 
 import com.grepp.spring.app.controller.api.schedules.payload.request.CreateSchedulesRequest;
+import com.grepp.spring.app.controller.api.schedules.payload.response.CreateSchedulesResponse;
 import com.grepp.spring.app.model.event.code.MeetingType;
 import com.grepp.spring.app.model.event.entity.Event;
 import com.grepp.spring.app.model.schedule.code.ScheduleStatus;
@@ -47,5 +48,11 @@ public class CreateScheduleDto {
             .status(dto.getScheduleStatus()) // 이벤트 -> 일정 생성 , 일정 픽스 2개의 상태가 있다. 생성 시 무조건 NONE으로 고정불가
             .scheduleName(dto.getScheduleName())
             .description(dto.getDescription()).build();
+    }
+
+    public static CreateSchedulesResponse toResponse(Long scheduleId) {
+        return CreateSchedulesResponse.builder()
+            .scheduleId(scheduleId)
+            .build();
     }
 }

--- a/src/main/java/com/grepp/spring/app/model/schedule/dto/ShowScheduleDto.java
+++ b/src/main/java/com/grepp/spring/app/model/schedule/dto/ShowScheduleDto.java
@@ -80,6 +80,7 @@ public class ShowScheduleDto {
 
         List<WorkspaceDto> workspaces = IntStream.range(0, workspace.size())
             .mapToObj(i-> new WorkspaceDto(
+                workspace.get(i).getId(),
                 workspacesType.get(i),
                 workspacesNames.get(i),
                 workspacesUrls.get(i)

--- a/src/main/java/com/grepp/spring/app/model/schedule/dto/WorkspaceDto.java
+++ b/src/main/java/com/grepp/spring/app/model/schedule/dto/WorkspaceDto.java
@@ -9,6 +9,7 @@ import lombok.Setter;
 @Setter
 @AllArgsConstructor
 public class WorkspaceDto {
+    private Long workspaceId;
     private WorkspaceType type;
     private String name;
     private String url;

--- a/src/main/java/com/grepp/spring/app/model/schedule/service/ScheduleCommandService.java
+++ b/src/main/java/com/grepp/spring/app/model/schedule/service/ScheduleCommandService.java
@@ -5,6 +5,7 @@ import com.grepp.spring.app.controller.api.schedules.payload.request.CreateSched
 import com.grepp.spring.app.controller.api.schedules.payload.request.AddWorkspaceRequest;
 import com.grepp.spring.app.controller.api.schedules.payload.request.ModifySchedulesRequest;
 import com.grepp.spring.app.controller.api.schedules.payload.response.CreateOnlineMeetingRoomResponse;
+import com.grepp.spring.app.controller.api.schedules.payload.response.CreateSchedulesResponse;
 import com.grepp.spring.app.controller.api.schedules.payload.response.ShowScheduleResponse;
 import com.grepp.spring.app.model.event.entity.Event;
 import com.grepp.spring.app.model.event.repository.EventRepository;
@@ -90,7 +91,7 @@ public class ScheduleCommandService {
     }
 
     @Transactional
-    public void createSchedule(CreateSchedulesRequest request) {
+    public CreateSchedulesResponse createSchedule(CreateSchedulesRequest request) {
         Optional<Event> eid = eventRepository.findById(request.getEventId());
 
         CreateScheduleDto dto = CreateScheduleDto.toDto(request);
@@ -115,6 +116,8 @@ public class ScheduleCommandService {
 
             scheduleMemberQueryRepository.save(scheduleMember);
         }
+
+        return CreateScheduleDto.toResponse(schedule.getId());
     }
 
     @Transactional // JPA 영속성 컨텍스트 변경 감지. setter를 사용해서 값 바꾸면 자동으로 변경

--- a/src/main/java/com/grepp/spring/app/model/schedule/service/ScheduleQueryService.java
+++ b/src/main/java/com/grepp/spring/app/model/schedule/service/ScheduleQueryService.java
@@ -73,6 +73,13 @@ public class ScheduleQueryService {
     }
 
     public Schedule findScheduleById(Long scheduleId) {
+
+//        if (scheduleQueryRepository.findById(scheduleId).isEmpty()) {
+//            throw new ScheduleNotFoundException(GroupErrorCode.SCHEDULE_NOT_FOUND);
+//        }
+//        return scheduleQueryRepository.findById(scheduleId).get();
+
+        // orElseThrow 는 빈 배열로 반환되어서
         return scheduleQueryRepository.findById(scheduleId).orElseThrow(() -> new ScheduleNotFoundException(
             GroupErrorCode.SCHEDULE_NOT_FOUND));
     }

--- a/src/main/resources/lkh.sql
+++ b/src/main/resources/lkh.sql
@@ -105,13 +105,13 @@ values (10,'10a',1, 'ROLE_MEMBER','이수역', 37.487521, 126.982309, '황수지
 
 -- 워크스페이스 테이블 생성
 insert into workspaces(id,schedule_id,type,name,url)
-values (1,1,'DISCORD','DOD discord','www.discord.com');
+values (1,1,'GITHUB','DOD github','www.github.com');
 
 insert into workspaces(id,schedule_id,type,name,url)
 values (2,1,'FIGMA','이때 어때 figma','www.figma.com');
 
 insert into workspaces(id,schedule_id,type,name,url)
-values (3,1,'ZEP','데브코스 zep','www.zep.com');
+values (3,1,'NOTION','데브코스 notion','www.notion.com');
 
 -- 장소 테이블 생성
 insert into locations(id,schedule_id, name, latitude, longitude,status)


### PR DESCRIPTION
## ✅ 관련 이슈
- close #113 

## 🛠️ 작업 내용
- 일정 생성 시 response에 scheduleId 추가
- MeetingPlatform ENUM 추가: DISCORD, ZEP
- WorkspaceType ENUM 변경 & 추가 : GITHUB, GOOGLE_DOCS, NOTION
- WorkspaceTye 삭제 : ZEP, DISCORD, GOOGLE_DOS

## 📸 스크린샷
- 일정 조회 시 workspaceId 반
<img width="1532" height="495" alt="image" src="https://github.com/user-attachments/assets/c6fa0f21-d585-4471-92cf-4d0a9d0738c1" />

- 일정 생성 시 scheduleId 반환
<img width="1533" height="214" alt="image" src="https://github.com/user-attachments/assets/c4e32067-866c-4b97-9e28-635481c3b953" />


## 🧩 기타 참고사항
MeetingPlatform , WorkspaceType ENUM 타입 변경되었습니다.
- MeetingPlatform ENUM 추가: DISCORD, ZEP
- WorkspaceType ENUM 변경 & 추가 : GITHUB, GOOGLE_DOCS, NOTION
- WorkspaceTye 삭제 : ZEP, DISCORD, GOOGLE_DOS
