### PR TITLE
♻️ refactor: 프로필 이미지 변경 기능 분리

### DIFF
--- a/src/main/java/com/grepp/spring/app/controller/api/auth/payload/request/RegisterRequest.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/auth/payload/request/RegisterRequest.java
@@ -11,7 +11,7 @@ public class RegisterRequest {
     private String role;
     private String email;
     private String name;
-    private Long profileImageNumber;
+    private Integer profileImageNumber;
     private String tel;
 
 }

--- a/src/main/java/com/grepp/spring/app/controller/api/member/MemberController.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/member/MemberController.java
@@ -70,8 +70,7 @@ public class MemberController {
         return ResponseEntity.ok(ApiResponse.noContent());
     }
 
-    @Operation(summary = "사용자 정보 수정", description = "현재 로그인 중인 사용자의 이름과 프로필 사진을 수정할 수 있습니다."
-        + "프로필 사진은 랜덤으로 변경됩니다.")
+    @Operation(summary = "사용자 정보 수정", description = "사용자의 이름을 수정합니다.")
     @PatchMapping("/me")
     public ResponseEntity<ApiResponse<ModifyMemberInfoResponse>> modifyMemberInfo(String username){
 
@@ -79,6 +78,17 @@ public class MemberController {
         String userId = authentication.getName();
 
         ModifyMemberInfoResponse response = memberService.modifyMemberInfo(userId, username);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "프로필 캐릭터 변경", description = "사용자의 프로필 캐릭터를 랜덤으로 변경합니다.")
+    @PatchMapping("/profile")
+    public ResponseEntity<ApiResponse<ModifyMemberInfoResponse>> modifyProfileImage(){
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String userId = authentication.getName();
+
+        ModifyMemberInfoResponse response = memberService.modifyProfileImage(userId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/src/main/java/com/grepp/spring/app/controller/api/member/payload/MemberInfoResponse.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/member/payload/MemberInfoResponse.java
@@ -10,7 +10,7 @@ public class MemberInfoResponse {
     private String id;
     private String email;
     private String name;
-    private Long profileImageNumber;
+    private Integer profileImageNumber;
     private String provider;
     private String role;
 

--- a/src/main/java/com/grepp/spring/app/controller/api/member/payload/ModifyMemberInfoResponse.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/member/payload/ModifyMemberInfoResponse.java
@@ -9,6 +9,6 @@ public class ModifyMemberInfoResponse {
 
     private String id;
     private String name;
-    private Long profileImageNumber;
+    private Integer profile;
 
 }

--- a/src/main/java/com/grepp/spring/app/model/auth/AuthService.java
+++ b/src/main/java/com/grepp/spring/app/model/auth/AuthService.java
@@ -70,7 +70,7 @@ public class AuthService {
             member.setName(userInfo.getName());
             member.setEmail(userInfo.getEmail());
             member.setRole(Role.ROLE_USER);
-            member.setProfileImageNumber((long) new Random().nextInt(10));
+            member.setProfileImageNumber(new Random().nextInt(8));
             member.setPassword("123qwe!@#");
             // 일단 전화번호는 나중에 받고
             // 프로필 사진은 모르겠다 일단 아무 숫자나 넣자

--- a/src/main/java/com/grepp/spring/app/model/member/entity/Member.java
+++ b/src/main/java/com/grepp/spring/app/model/member/entity/Member.java
@@ -18,6 +18,10 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Pattern;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.Getter;
@@ -34,6 +38,7 @@ public class Member extends BaseEntity {
     @Column(nullable = false, updatable = false)
     private String id;
 
+    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[!@#$%^&*()_+=-]).{8,20}$", message = "비밀번호는 영문, 숫자, 특수문자를 포함한 8~20자여야 합니다.")
     @Column(nullable = false)
     private String password;
 
@@ -45,6 +50,7 @@ public class Member extends BaseEntity {
     @Column(nullable = false)
     private Role role;
 
+    @Email
     @Column(nullable = false, unique = true)
     private String email;
 
@@ -52,9 +58,12 @@ public class Member extends BaseEntity {
     private String name;
 
     @Column(nullable = false)
-    private Long profileImageNumber;
+    @Min(0)
+    @Max(7)
+    private Integer profileImageNumber;
 
     @Column(nullable = true, unique = true) // 잠깐 나가있어
+    @Pattern(regexp = "^01(?:0|1|[6-9])-(?:\\d{3}|\\d{4})-\\d{4}$", message = "유효하지 않은 전화번호 형식입니다. (예: 010-1234-5678)")
     private String tel;
 
     // 멤버가 삭제되면 그 멤버의 소셜 토큰도 삭제

--- a/src/main/java/com/grepp/spring/app/model/member/service/MemberService.java
+++ b/src/main/java/com/grepp/spring/app/model/member/service/MemberService.java
@@ -142,6 +142,8 @@ public class MemberService {
         int randomIndex = random.nextInt(members.size());
         return members.get(randomIndex);
     }
+
+    // 이름 변경
     @Transactional
     public ModifyMemberInfoResponse modifyMemberInfo(String userId, String username) {
 
@@ -155,10 +157,10 @@ public class MemberService {
             validateName(username);
             member.setName(username);
         }
-        member.setProfileImageNumber((long) new Random().nextInt(10));
+//        member.setProfileImageNumber((long) new Random().nextInt(10));
 
         memberRepository.save(member);
-        log.info("프로필이 변경되었습니다. 이름: {}, 프로필 사진 번호: {}", member.getName(), member.getProfileImageNumber());
+        log.info("프로필이 변경되었습니다. 이름: {}", member.getName());
 
         // 변경된 사용자 정보 리턴 (나중에 응답에 넣을 거임)
         return new ModifyMemberInfoResponse(member.getId(), member.getName(), member.getProfileImageNumber());
@@ -179,5 +181,24 @@ public class MemberService {
         if (!username.matches(pattern)) {
             throw new InvalidNameException("이름은 한글, 영문만 사용 가능하며, 숫자나 특수문자는 포함할 수 없습니다.");
         }
+    }
+
+    // 프로필 사진 변경
+    @Transactional
+    public ModifyMemberInfoResponse modifyProfileImage(String userId) {
+
+        Member member = memberRepository.findById(userId)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+
+        // 기존의 프로필 번호
+        int currentProfileNumber = member.getProfileImageNumber();
+        int newProfileNumber;
+        Random random = new Random();
+        do {
+            newProfileNumber = random.nextInt(8);
+        } while (newProfileNumber == currentProfileNumber); //기존 번호와 같으면 다시
+
+        member.setProfileImageNumber(newProfileNumber);
+        return new ModifyMemberInfoResponse(member.getId(), member.getName(), member.getProfileImageNumber());
     }
 }


### PR DESCRIPTION
## ✅ 관련 이슈
- close #115

## 🛠️ 작업 내용
- 프로필 수정 API를 프로필 사진 변경과 이름 수정 기능으로 분리
- 지정된 프로필의 개수를 10 > 8개로 변경 (프론트 측 요청)
- Member 필드 검증 정규표현식 추가(전화번호, 이메일, 프로필 번호 등)
- Member 엔티티의 profileImageNumber 타입 변경 (long -> Integer)

## 🧩 기타 참고사항
- PR 완료 후 DB Create 바랍니다!