### PR TITLE
🐛 fix	버그 수정

### DIFF
--- a/src/main/java/com/grepp/spring/app/model/group/service/GroupQueryStatisticsService.java
+++ b/src/main/java/com/grepp/spring/app/model/group/service/GroupQueryStatisticsService.java
@@ -32,6 +32,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Slf4j
@@ -46,6 +47,7 @@ public class GroupQueryStatisticsService {
     private final ScheduleMemberQueryRepository scheduleMemberQueryRepository;
 
     // 그룹 통계 조회
+    @Transactional(readOnly = true)
     public ShowGroupStatisticsResponse displayStatistics(Long groupId) {
         // http 요청 사용자 조회
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();


### PR DESCRIPTION
Group의 통계 조회 시 멤버들의 이름이 출력되도록 수정


## ✅ 관련 이슈
- close #128

## 🛠️ 작업 내용
- 통계 조회 시 memberId가 아닌 memberName별로 조회

## 📸 스크린샷 (선택)
<img width="1276" height="645" alt="image" src="https://github.com/user-attachments/assets/a89a958d-e7d5-4fe4-89ef-015be2be6d95" />

## 🧩 기타 참고사항
- 현재 빠른 개발을 위해 lazy fetch를 쉽게 하기 위해 Transactional(readOnly=true)로 설정해 놨습니다.
- 기능 고도화 시 수정될 사항입니다.
