### PR TITLE
✨ feat: 이벤트 조회에 groupId 응답 값 추가

### DIFF
--- a/src/main/java/com/grepp/spring/app/controller/api/event/payload/response/ShowEventResponse.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/event/payload/response/ShowEventResponse.java
@@ -20,4 +20,7 @@ public class ShowEventResponse {
 
     @Schema(description = "요청한 사용자의 역할", example = "ROLE_MASTER")
     private String role;
+
+    @Schema(description = "그룹 ID", example = "6789")
+    private Long groupId;
 }

--- a/src/main/java/com/grepp/spring/app/model/event/service/EventService.java
+++ b/src/main/java/com/grepp/spring/app/model/event/service/EventService.java
@@ -106,6 +106,7 @@ public class EventService {
         response.setTitle(event.getTitle());
         response.setDescription(event.getDescription());
         response.setRole(eventMember.getRole().name());
+        response.setGroupId(event.getGroup().getId());
 
         return response;
     }


### PR DESCRIPTION
## ✅ 관련 이슈
- close #139 

## 🛠️ 작업 내용
- 이벤트 조회에서 응답 값으로 groupId를 추가

## 📸 스크린샷
- 변경 전 응답
<img width="613" height="190" alt="image" src="https://github.com/user-attachments/assets/adeafbe4-9a48-4561-ad9b-376095911dd3" />

- 변경 후 응답
<img width="612" height="202" alt="image" src="https://github.com/user-attachments/assets/98c01e32-a8d0-47dd-acb5-510b4faf90f1" />

