### PR TITLE
🐛 fix	그룹 내 멤버 조회 시 각 멤버별 프로필 넘버 전달

### DIFF
--- a/src/main/java/com/grepp/spring/app/model/group/dto/GroupUser.java
+++ b/src/main/java/com/grepp/spring/app/model/group/dto/GroupUser.java
@@ -9,5 +9,6 @@ import lombok.Data;
 public class GroupUser {
     private String userId;
     private String userName;
+    private Integer profileImageNumber;
     private GroupRole groupRole;
 }

--- a/src/main/java/com/grepp/spring/app/model/group/service/GroupQueryService.java
+++ b/src/main/java/com/grepp/spring/app/model/group/service/GroupQueryService.java
@@ -152,9 +152,10 @@ public class GroupQueryService {
         for (GroupMember groupMember : groupMembers) {
             String memberId = groupMember.getMember().getId();
             String memberName = memberRepository.findById(memberId).get().getName();
+            Integer profileImageNumber = memberRepository.findById(memberId).get().getProfileImageNumber();
             GroupRole groupRole = groupMember.getRole();
             // 멤버Id, 이름, 권한으로 GroupUser 리스트에 추가
-            groupUsers.add(new GroupUser(memberId, memberName, groupRole));
+            groupUsers.add(new GroupUser(memberId, memberName, profileImageNumber, groupRole));
             // http요청을 날린 멤버의 Id가 현재 탐색중인 member의 Id가 같다면, group에 해당 member 포함됨.
             if (memberId.equals(member.getId())) {
                 checking = true;


### PR DESCRIPTION
🐛 fix 그룹 내 멤버 조회 시 각 멤버별 프로필 넘버 전달

## ✅ 관련 이슈
- close #138

## 🛠️ 작업 내용
- 그룹 멤버에 대한 조회 시 프로필 넘버 추가
- 프론트 팀의 요청 사항

## 🧩 기타 참고사항
- X