### PR TITLE
토큰 관리 방식 변경

### DIFF
--- a/src/main/java/com/grepp/spring/app/model/auth/token/RefreshTokenService.java
+++ b/src/main/java/com/grepp/spring/app/model/auth/token/RefreshTokenService.java
@@ -1,0 +1,34 @@
+package com.grepp.spring.app.model.auth.token;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.grepp.spring.app.model.auth.token.entity.RefreshToken;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RefreshTokenService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    public void saveWithAtId(RefreshToken refreshToken){
+        redisTemplate.opsForValue().set(
+            refreshToken.getAtId(), // Redis 의 key 로 사용할 엑세스 토큰 Jti
+            refreshToken,
+            Duration.ofSeconds(refreshToken.getTtl()));
+    }
+
+    public void deleteByAccessTokenId(String atId) {
+        redisTemplate.delete(atId);
+    }
+
+    public RefreshToken findByAccessTokenId(String atId) {
+        return objectMapper.convertValue(redisTemplate.opsForValue().get(atId), RefreshToken.class);
+    }
+
+}

--- a/src/main/java/com/grepp/spring/app/model/auth/token/entity/RefreshToken.java
+++ b/src/main/java/com/grepp/spring/app/model/auth/token/entity/RefreshToken.java
@@ -11,14 +11,9 @@ import lombok.Setter;
 @Setter
 @Builder
 @AllArgsConstructor
+@NoArgsConstructor
 public class RefreshToken {
-    private String id = UUID.randomUUID().toString();
-    private String atId;
-    private String token = UUID.randomUUID().toString();
+    private String id = UUID.randomUUID().toString(); // 리프레시 토큰 id
+    private String atId; // 연결된 엑세스 토큰의 JTI
     private Long ttl = 3600 * 24 * 7L;
-    private Long expires;
-    
-    public RefreshToken(String atId) {
-        this.atId = atId;
-    }
 }

--- a/src/main/java/com/grepp/spring/infra/auth/jwt/dto/RefreshTokenDto.java
+++ b/src/main/java/com/grepp/spring/infra/auth/jwt/dto/RefreshTokenDto.java
@@ -1,0 +1,15 @@
+package com.grepp.spring.infra.auth.jwt.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Builder
+@Getter @Setter
+public class RefreshTokenDto {
+
+    private String jti;
+    private String token;
+    private Long expires;
+
+}

--- a/src/main/java/com/grepp/spring/infra/auth/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/grepp/spring/infra/auth/jwt/filter/JwtAuthenticationFilter.java
@@ -1,13 +1,10 @@
 package com.grepp.spring.infra.auth.jwt.filter;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.grepp.spring.app.model.auth.code.AuthToken;
-import com.grepp.spring.app.model.auth.token.entity.RefreshToken;
 import com.grepp.spring.infra.auth.jwt.JwtTokenProvider;
-import com.grepp.spring.infra.auth.jwt.TokenCookieFactory;
-import com.grepp.spring.infra.auth.jwt.dto.AccessTokenDto;
-import com.grepp.spring.infra.error.exceptions.CommonException;
+import com.grepp.spring.infra.response.ApiResponse;
 import com.grepp.spring.infra.response.ResponseCode;
-import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -17,9 +14,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.JwtException;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -27,7 +24,6 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
-//    private final UserBlackListRepository userBlackListRepository;
     private final JwtTokenProvider jwtTokenProvider;
 
     @Override
@@ -42,7 +38,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
         FilterChain filterChain) throws ServletException, IOException {
+
         String accessToken = jwtTokenProvider.resolveToken(request, AuthToken.ACCESS_TOKEN);
+
+        // 엑세스 토큰이 없는 경우 → 인증 없이도 접근 가능한 요청은 패스
         if (accessToken == null) {
             filterChain.doFilter(request, response);
             return;
@@ -53,61 +52,23 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             }
+            filterChain.doFilter(request, response);
+
         } catch (ExpiredJwtException e) {
-            manageTokenRefresh(accessToken, request, response);
+            // 엑세스 토큰이 만료된 경우
+            sendErrorResponse(response, ResponseCode.EXPIRED_TOKEN, ResponseCode.EXPIRED_TOKEN.message());
+        } catch (JwtException | IllegalArgumentException e) {
+            // 유효하지 않은 토큰인 경우
+            sendErrorResponse(response, ResponseCode.INVALID_TOKEN, ResponseCode.INVALID_TOKEN.message());
         }
-        filterChain.doFilter(request, response);
     }
 
-    private void manageTokenRefresh(
-        String accessToken,
-        HttpServletRequest request,
-        HttpServletResponse response) throws IOException {
+    private void sendErrorResponse(HttpServletResponse response, ResponseCode code, String message) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json;charset=UTF-8");
 
-        // 엑세스 토큰에서 정보(claim) 추출
-        Claims claims  = jwtTokenProvider.getClaims(accessToken);
-        String userId = claims.getSubject();
-        String accessTokenId = claims.getId();
-
-        String refreshToken = jwtTokenProvider.resolveToken(request, AuthToken.REFRESH_TOKEN);
-
-        if (refreshToken == null){
-            throw new CommonException(ResponseCode.INVALID_TOKEN);
-        }
-
-        // 리프레시 토큰에서 claim 추출
-        Claims refreshTokenClaims = jwtTokenProvider.getClaims(refreshToken);
-        // 그로부터 Access Token ID 추출
-        String atId = (String) refreshTokenClaims.get("atId");
-
-        if (!accessTokenId.equals(atId)) {
-            // 추후 블랙리스트 처리 고려 -> Redis
-            throw new CommonException(ResponseCode.SECURITY_INCIDENT);
-        }
-
-        addToken(response, userId, (String) claims.get("roles"));
-    }
-
-    private void addToken(HttpServletResponse response, String userId, String roles) {
-
-        // 새로운 엑세스 토큰 생성
-        AccessTokenDto newAccessToken = jwtTokenProvider.generateAccessToken(userId, roles);
-
-        // 새로운 엑세스 토큰의 JTI를 사용하여 새로운 리프레시 토큰 생성
-        RefreshToken newRefreshToken = jwtTokenProvider.generateRefreshToken(newAccessToken.getJti());
-
-        // SecurityContextHolder에 인증 정보를 업데이트 해야함.
-        // 새로운 엑세스 토큰으로 인증 객체를 생성하고 Context에 지정해줍시다.
-        Authentication authentication = jwtTokenProvider.getAuthentication(newAccessToken.getToken());
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-
-        // client 요청에 자동으로 포함되도록 쿠키에 넣어주기
-        ResponseCookie accessTokenCookie = TokenCookieFactory.create(AuthToken.ACCESS_TOKEN.name(),
-            newAccessToken.getToken(), newAccessToken.getExpires());
-        ResponseCookie refreshTokenCookie = TokenCookieFactory.create(AuthToken.REFRESH_TOKEN.name(),
-            newRefreshToken.getToken(), newRefreshToken.getTtl());
-
-        response.addHeader("Set-Cookie", accessTokenCookie.toString());
-        response.addHeader("Set-Cookie", refreshTokenCookie.toString());
+        ApiResponse<?> errorResponse = ApiResponse.error(code, message);
+        String json = new ObjectMapper().writeValueAsString(errorResponse);
+        response.getWriter().write(json);
     }
 }

--- a/src/main/java/com/grepp/spring/infra/config/RedisConfig.java
+++ b/src/main/java/com/grepp/spring/infra/config/RedisConfig.java
@@ -1,0 +1,52 @@
+package com.grepp.spring.infra.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+    
+    @Value("${spring.data.redis.port}")
+    private int port;
+    
+    @Value("${spring.data.redis.host}")
+    private String host;
+    
+    @Value("${spring.data.redis.username}")
+    private String username;
+    
+    @Value("${spring.data.redis.password}")
+    private String password;
+    
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+        redisStandaloneConfiguration.setHostName(host);
+        redisStandaloneConfiguration.setPort(port);
+        redisStandaloneConfiguration.setUsername(username);
+        redisStandaloneConfiguration.setPassword(password);
+        return new LettuceConnectionFactory(redisStandaloneConfiguration);
+    }
+    
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(
+        RedisConnectionFactory redisConnectionFactory,
+        ObjectMapper objectMapper) {
+        
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper));
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/grepp/spring/infra/error/AuthExceptionAdvice.java
+++ b/src/main/java/com/grepp/spring/infra/error/AuthExceptionAdvice.java
@@ -2,12 +2,9 @@ package com.grepp.spring.infra.error;
 
 import com.grepp.spring.infra.error.exceptions.AuthApiException;
 import com.grepp.spring.infra.response.ApiResponse;
-import com.grepp.spring.infra.response.ResponseCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -26,13 +23,13 @@ public class AuthExceptionAdvice {
                    .body(ApiResponse.error(ex.code()));
     }
     
-    @ResponseBody
-    @ExceptionHandler(AuthenticationException.class)
-    public ResponseEntity<ApiResponse<String>> authExHandler(
-        AuthenticationException ex) {
-        log.error(ex.getMessage(), ex);
-        return ResponseEntity
-                   .status(HttpStatus.UNAUTHORIZED)
-                   .body(ApiResponse.error(ResponseCode.UNAUTHORIZED));
-    }
+//    @ResponseBody
+//    @ExceptionHandler(AuthenticationException.class)
+//    public ResponseEntity<ApiResponse<String>> authExHandler(
+//        AuthenticationException ex) {
+//        log.error(ex.getMessage(), ex);
+//        return ResponseEntity
+//                   .status(HttpStatus.UNAUTHORIZED)
+//                   .body(ApiResponse.error(ResponseCode.UNAUTHORIZED));
+//    }
 }

--- a/src/main/java/com/grepp/spring/infra/error/RestApiExceptionAdvice.java
+++ b/src/main/java/com/grepp/spring/infra/error/RestApiExceptionAdvice.java
@@ -1,6 +1,7 @@
 package com.grepp.spring.infra.error;
 
 import com.grepp.spring.infra.error.exceptions.CommonException;
+import com.grepp.spring.infra.error.exceptions.member.InvalidTokenException;
 import com.grepp.spring.infra.response.ApiResponse;
 import com.grepp.spring.infra.response.ResponseCode;
 import java.util.LinkedHashMap;
@@ -62,6 +63,14 @@ public class RestApiExceptionAdvice {
         return ResponseEntity
             .internalServerError()
             .body(ApiResponse.error(ResponseCode.INTERNAL_SERVER_ERROR));
+    }
+
+    @ExceptionHandler(InvalidTokenException.class)
+    public ResponseEntity<ApiResponse<Void>> handleInvalidTokenException(InvalidTokenException ex) {
+        log.info("유효하지 않은 토큰 예외");
+        return ResponseEntity
+            .status(HttpStatus.UNAUTHORIZED)
+            .body(ApiResponse.error(ex.getResponseCode(), ex.getMessage()));
     }
 
 

--- a/src/main/java/com/grepp/spring/infra/error/exceptions/member/InvalidTokenException.java
+++ b/src/main/java/com/grepp/spring/infra/error/exceptions/member/InvalidTokenException.java
@@ -1,0 +1,16 @@
+package com.grepp.spring.infra.error.exceptions.member;
+
+import com.grepp.spring.infra.response.ResponseCode;
+
+public class InvalidTokenException extends RuntimeException {
+    private final ResponseCode responseCode;
+
+    public InvalidTokenException(ResponseCode responseCode, String message) {
+        super(message);
+        this.responseCode = responseCode;
+    }
+
+    public ResponseCode getResponseCode() {
+        return responseCode;
+    }
+}

--- a/src/main/java/com/grepp/spring/infra/response/ResponseCode.java
+++ b/src/main/java/com/grepp/spring/infra/response/ResponseCode.java
@@ -19,6 +19,7 @@ public enum ResponseCode {
     NOT_EXIST_PRE_AUTH_CREDENTIAL("401", HttpStatus.OK, "사전 인증 정보가 요청에서 발견되지 않았습니다."),
     INTERNAL_SERVER_ERROR("500", HttpStatus.INTERNAL_SERVER_ERROR, "서버에러 입니다."),
     SECURITY_INCIDENT("600", HttpStatus.OK, "비정상적인 로그인 시도가 감지되었습니다."),
+    EXPIRED_TOKEN("401", HttpStatus.UNAUTHORIZED, "엑세스 토큰이 만료되었습니다. 토큰을 갱신해주세요."),
     NOT_ALLOWED_WITHDRAW("403", HttpStatus.FORBIDDEN, "관리자 권한을 양도할 수 없는 그룹이 존재하여 탈퇴할 수 없습니다.");
     
     private final String code;

--- a/src/main/resources/init.sql
+++ b/src/main/resources/init.sql
@@ -1,2 +1,2 @@
 INSERT INTO Members (id, password, provider, role, email, name, profile_image_number, tel)
-VALUES ('GOOGLE_1234', '{noop}123qwe!@#', 'GOOGLE', 'ROLE_USER', 'test@gmail.com', '하명도', 1010101, '010-1234-5678');
+VALUES ('GOOGLE_1234', '{noop}123qwe!@#', 'GOOGLE', 'ROLE_USER', 'test@gmail.com', '하명도', 3, '010-1234-5678');


### PR DESCRIPTION
## ✅ 관련 이슈
- close #136 

## 🛠️ 작업 내용
- 리프레시 토큰을 Redis에 저장하도록 리팩토링을 진행했습니다.
  - 이제 토큰 검증 방식이 유효성 검사 뿐만아니라 Redis에 저장된 토큰과 비교하는 것을 포함합니다.
  - 엑세스 토큰 갱신 시 Redis에 저장된 Refresh Token도 갱신됩니다.
  - 갱신 이전의 토큰은 무효화 됩니다.
- 로그아웃 시 토큰이 무효화됩니다. (Redis에서 삭제)

## 📸 스크린샷
- 인증과 관련된 예외 처리는 Security FilterChain을 통해 처리할 생각이었는데, 
  전역적인 처리로 예외를 처리할 수가 없어서 아직 완벽한 예외처리가 어려운 상태입니다. 필터는 난이도가 너무 높네요.
<img width="1099" height="787" alt="스크린샷 2025-07-18 233121" src="https://github.com/user-attachments/assets/4c5332c0-a0fe-4406-aa60-bb44693a88ab" />

우선 토큰과 관련된 예외를 세분화했습니다.
각각 로그인, 토큰 갱신, 잘못된 접근으로 클라이언트가 처리할 수 있도록 했습니다.

- 토큰이 없는 경우
<img width="1375" height="479" alt="스크린샷 2025-07-18 222133" src="https://github.com/user-attachments/assets/e694f002-a0fd-4147-8b2f-9f04e57965d1" />
- 엑세스 토큰이 만료된 경우
<img width="1372" height="466" alt="스크린샷 2025-07-18 222540" src="https://github.com/user-attachments/assets/9472f515-cf4b-4b77-8795-6d47709408af" />
- 유효하지 않은 토큰인 경우
<img width="793" height="471" alt="스크린샷 2025-07-18 234622" src="https://github.com/user-attachments/assets/05ce3dd0-d206-422a-8ddc-9beb3c52b2a3" />

## 🧩 기타 참고사항
- 논의가 필요한 부분, 참고 링크, 특이사항 등
- 예: `X 기능`은 다음 PR에서 작업 예정입니다.
