### PR TITLE
✨ feat: 줌 회의장 개설 기능 구현

### DIFF
--- a/src/main/java/com/grepp/spring/app/controller/api/schedules/ScheduleController.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/schedules/ScheduleController.java
@@ -23,12 +23,14 @@ import com.grepp.spring.app.model.schedule.repository.ScheduleMemberQueryReposit
 import com.grepp.spring.app.model.schedule.service.ScheduleCommandService;
 import com.grepp.spring.app.model.schedule.service.ScheduleQueryService;
 import com.grepp.spring.infra.error.exceptions.AuthApiException;
+import com.grepp.spring.infra.error.exceptions.NotFoundException;
 import com.grepp.spring.infra.response.ApiResponse;
 import com.grepp.spring.infra.response.ResponseCode;
 import io.swagger.v3.oas.annotations.Operation;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -163,15 +165,14 @@ public class ScheduleController {
             return ResponseEntity.ok(ApiResponse.success("성공적으로 투표를 진행했습니다."));
     }
 
-    // 온라인 회의장 링크 개설(줌, 구글미트)
-    @Operation(summary = "온라인 회의장 링크 개설(줌, 구글미트)", description = "온라인 회의장을 개설합니다.")
+    // 온라인 회의장 링크 개설(줌)
+    @Operation(summary = "온라인 회의장 링크 개설(줌)", description = "온라인 회의장을 개설합니다.")
     @PostMapping("/create-online-meeting/{scheduleId}")
     public ResponseEntity<ApiResponse<CreateOnlineMeetingRoomResponse>> CreateOnlineMeetingRoom(@PathVariable Long scheduleId) {
 
-            scheduleQueryService.findScheduleById(scheduleId);
-            CreateOnlineMeetingRoomResponse response = scheduleCommandService.createOnlineMeeting(scheduleId);
+        CreateOnlineMeetingRoomResponse response = scheduleCommandService.createOnlineMeeting(scheduleId);
 
-            return ResponseEntity.ok(ApiResponse.success(response));
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     // 공통 워크스페이스 등록

--- a/src/main/java/com/grepp/spring/app/model/schedule/dto/CreateOnlineMeetingRoomDto.java
+++ b/src/main/java/com/grepp/spring/app/model/schedule/dto/CreateOnlineMeetingRoomDto.java
@@ -15,7 +15,7 @@ public class CreateOnlineMeetingRoomDto {
 
     public static CreateOnlineMeetingRoomDto toDto(String url) {
         return CreateOnlineMeetingRoomDto.builder()
-            .meetingPlatform(MeetingPlatform.GOOGLE_MEET)
+            .meetingPlatform(MeetingPlatform.ZOOM)
             .workspaceUrl(url)
             .build();
     }

--- a/src/main/java/com/grepp/spring/app/model/schedule/dto/ZoomMeetingDto.java
+++ b/src/main/java/com/grepp/spring/app/model/schedule/dto/ZoomMeetingDto.java
@@ -1,0 +1,10 @@
+package com.grepp.spring.app.model.schedule.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+public class ZoomMeetingDto {
+    @JsonProperty("join_url")
+    private String joinUrl;
+}

--- a/src/main/java/com/grepp/spring/app/model/schedule/service/ZoomOAuthService.java
+++ b/src/main/java/com/grepp/spring/app/model/schedule/service/ZoomOAuthService.java
@@ -1,0 +1,51 @@
+package com.grepp.spring.app.model.schedule.service;
+
+import com.grepp.spring.app.controller.api.mypage.payload.response.GoogleTokenResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Base64;
+
+@Service
+@RequiredArgsConstructor
+public class ZoomOAuthService {
+
+    @Value("${zoom.client-id}")
+    private String clientId;
+
+    @Value("${zoom.client-secret}")
+    private String clientSecret;
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    public GoogleTokenResponse refreshAccessToken(String refreshToken) {
+        String url = "https://zoom.us/oauth/token";
+        HttpHeaders headers = createBasicAuthHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "refresh_token");
+        params.add("refresh_token", refreshToken);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+        ResponseEntity<GoogleTokenResponse> response = restTemplate.postForEntity(url, request, GoogleTokenResponse.class);
+        return response.getBody();
+    }
+
+    private HttpHeaders createBasicAuthHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        String auth = clientId + ":" + clientSecret;
+        byte[] encodedAuth = Base64.getEncoder().encode(auth.getBytes());
+        String authHeader = "Basic " + new String(encodedAuth);
+        headers.set("Authorization", authHeader);
+        return headers;
+    }
+}


### PR DESCRIPTION
## ✅ 관련 이슈
- close #146 

## 🛠️ 작업 내용
- 줌 회의장 개설 기능 구현
  - 사용자 요청 시 서비스 계정으로 줌 회의장을 대신 개설
  - 회의장 개설 시 schedules 테이블에 meeting_platform과 platform_url 저장

## 📸 스크린샷
- schedules 테이블 (일부)
<img width="549" height="50" alt="스크린샷 2025-07-19 오후 10 48 45" src="https://github.com/user-attachments/assets/8e808f80-0679-418a-8213-283fd406e894" />

- API 응답
<img width="855" height="166" alt="스크린샷 2025-07-19 오후 10 52 08" src="https://github.com/user-attachments/assets/a24abd31-1db4-4257-81e2-8af3a2081bd3" />

## 🧩 기타 참고사항
application.yml에 Zoom 관련 값을 추가해야 합니다. slack 확인 부탁드립니다.
