### PR TITLE
♻️ refactor:  메인페이지 예외처리  + dto 수정

### DIFF
--- a/src/main/java/com/grepp/spring/app/controller/api/group/payload/response/ShowGroupResponse.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/group/payload/response/ShowGroupResponse.java
@@ -3,6 +3,7 @@ package com.grepp.spring.app.controller.api.group.payload.response;
 import com.grepp.spring.app.model.group.dto.GroupDetailDto;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;

--- a/src/main/java/com/grepp/spring/app/controller/api/mainpage/MainPageController.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/mainpage/MainPageController.java
@@ -90,7 +90,7 @@ public class MainPageController {
     );
 
     Map<LocalDate, List<UnifiedScheduleDto>> monthlySchedules =
-        calendarService.getMonthlySchedules(memberId, startDate, endDate);
+        calendarService.getSchedulesInRange(memberId, startDate, endDate);
 
     return ApiResponse.success("월간 일정 조회 성공",monthlySchedules);
   }

--- a/src/main/java/com/grepp/spring/app/controller/api/mypage/CalendarOAuthController.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/mypage/CalendarOAuthController.java
@@ -61,7 +61,8 @@ public class CalendarOAuthController {
       // 수동 새로고침 로직 호출
       calendarSyncService.syncCalendar(memberId);
 
-      //response.sendRedirect("http://localhost:8080/mypage/google-calendar");
+      // 로컬
+      // response.sendRedirect("http://localhost:8080/mypage/google-calendar");
       // 프론트로 보내는 uri
       response.sendRedirect("https://ittaeok.uk/mypage?google-sync=success");
     } catch (GoogleAuthFailedException e) {

--- a/src/main/java/com/grepp/spring/app/model/group/dto/GroupDetailDto.java
+++ b/src/main/java/com/grepp/spring/app/model/group/dto/GroupDetailDto.java
@@ -1,14 +1,45 @@
 package com.grepp.spring.app.model.group.dto;
 
+import com.grepp.spring.app.model.group.code.GroupRole;
+import com.grepp.spring.app.model.group.entity.Group;
+import com.grepp.spring.app.model.group.entity.GroupMember;
+import java.util.List;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 
 @Data
 @AllArgsConstructor
+@Builder
 public class GroupDetailDto {
     private Long groupId;
     private String groupName;
     private String description;
     private Integer groupMemberNum;
+    private Integer leaderProfileImage;
+
+    public static GroupDetailDto from(Group group, List<GroupMember> allGroupMembers) {
+
+        // 이 그룹에 속한 멤버 수 카운트
+        int memberCount = (int) allGroupMembers.stream()
+            .filter(gm -> gm.getGroup().getId().equals(group.getId()))
+            .count();
+
+        // 그룹장 이미지 찾기
+        Integer leaderProfileImage = allGroupMembers.stream()
+            .filter(gm -> gm.getGroup().getId().equals(group.getId()))
+            .filter(gm -> gm.getRole() == GroupRole.GROUP_LEADER)
+            .findFirst()
+            .map(gm -> gm.getMember().getProfileImageNumber())
+            .orElse(null);
+
+        return GroupDetailDto.builder()
+            .groupId(group.getId())
+            .groupName(group.getName())
+            .description(group.getDescription())
+            .groupMemberNum(memberCount)      // 멤버 수 세팅
+            .leaderProfileImage(leaderProfileImage) // 그룹장 이미지만 추가
+            .build();
+    }
 
 }

--- a/src/main/java/com/grepp/spring/app/model/mainpage/dto/UnifiedScheduleDto.java
+++ b/src/main/java/com/grepp/spring/app/model/mainpage/dto/UnifiedScheduleDto.java
@@ -69,7 +69,7 @@ public class UnifiedScheduleDto { //  for (구글 일정 + 내부 일정) 하나
         .location(s.getLocation())
         .specificLocation(s.getSpecificLocation())
         .isGrouped(g.getIsGrouped()) // 필요하면 s.getEvent() != null 로 변경
-        .groupName(g.getName())  // 그룹 일정이면 s.getEvent().getGroup().getName()
+        .groupName(g.getIsGrouped() ? g.getName() : null)  // 그룹 일정이면 s.getEvent().getGroup().getName()
 //      .groupMemberName(memberNames)
         .participantNames(participantNames)
         .meetingType(s.getEvent().getMeetingType()) // 아직 MeetingType이 없다면 null 처리

--- a/src/main/java/com/grepp/spring/app/model/mainpage/dto/UnifiedScheduleDto.java
+++ b/src/main/java/com/grepp/spring/app/model/mainpage/dto/UnifiedScheduleDto.java
@@ -34,8 +34,8 @@ public class UnifiedScheduleDto { //  for (구글 일정 + 내부 일정) 하나
   private String specificLocation;
   private Boolean isGrouped;          // 그룹 일정 여부
   private String groupName;           // 그룹명 (그룹 일정일 경우)
-  private String groupMemberName;
-  private Integer profileImageNumber;
+//private String groupMemberName;
+  private String participantNames;
   private MeetingType meetingType;    // ON/OFF
   private MeetingPlatform meetingPlatform;
   private ScheduleStatus scheduleStatus; // recommend, fixed, complete
@@ -48,17 +48,16 @@ public class UnifiedScheduleDto { //  for (구글 일정 + 내부 일정) 하나
       Schedule s,
       Group g,
       ScheduleMember sm ,
-      List<GroupMember> groupMembers) {
+//    List<GroupMember> groupMembers,
+      List<ScheduleMember> scheduleMembers
+  ) {
 
-    // 그룹원 리스트 중 그룹장만 찾아서 프로필 이미지 번호 가져오기
-    Integer leaderProfileImage = groupMembers.stream()
-        .filter(member -> member.getRole() == GroupRole.GROUP_LEADER)
-        .findFirst()
-        .map(member -> member.getMember().getProfileImageNumber())
-        .orElse(null);
+//    String memberNames = groupMembers.stream()
+//        .map(member -> member.getMember().getName())
+//        .collect(Collectors.joining(", "));
 
-    String memberNames = groupMembers.stream()
-        .map(member -> member.getMember().getName()) // 필요하면 getName()
+    String participantNames = scheduleMembers.stream()
+        .map(m -> m.getMember().getName()) // Member 엔티티에서 이름 꺼내기
         .collect(Collectors.joining(", "));
 
     return UnifiedScheduleDto.builder()
@@ -71,8 +70,8 @@ public class UnifiedScheduleDto { //  for (구글 일정 + 내부 일정) 하나
         .specificLocation(s.getSpecificLocation())
         .isGrouped(g.getIsGrouped()) // 필요하면 s.getEvent() != null 로 변경
         .groupName(g.getName())  // 그룹 일정이면 s.getEvent().getGroup().getName()
-        .groupMemberName(memberNames)
-        .profileImageNumber(leaderProfileImage)
+//      .groupMemberName(memberNames)
+        .participantNames(participantNames)
         .meetingType(s.getEvent().getMeetingType()) // 아직 MeetingType이 없다면 null 처리
         .meetingPlatform(s.getMeetingPlatform())
         .scheduleStatus(s.getStatus())

--- a/src/main/java/com/grepp/spring/app/model/mainpage/repository/MainPageScheduleRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/mainpage/repository/MainPageScheduleRepository.java
@@ -19,7 +19,7 @@ public interface MainPageScheduleRepository extends JpaRepository<Schedule, Long
     FROM Schedule s
     JOIN s.scheduleMembers sm
     JOIN FETCH s.event e
-    JOIN FETCH e.group g
+    LEFT JOIN FETCH e.group g
     LEFT JOIN FETCH g.groupMembers gm
     LEFT JOIN FETCH gm.member m
     WHERE sm.member.id = :memberId

--- a/src/main/java/com/grepp/spring/app/model/mainpage/service/CalendarService.java
+++ b/src/main/java/com/grepp/spring/app/model/mainpage/service/CalendarService.java
@@ -28,7 +28,7 @@ public class CalendarService {
   private final GoogleScheduleRepository googleScheduleRepository;
   private final ScheduleMemberRepository scheduleMemberRepository;
 
-  public Map<LocalDate, List<UnifiedScheduleDto>> getMonthlySchedules(
+  public Map<LocalDate, List<UnifiedScheduleDto>> getSchedulesInRange(
       String memberId,
       LocalDate startDate,
       LocalDate endDate
@@ -50,12 +50,13 @@ public class CalendarService {
         .map(schedule -> {
           Group group = schedule.getEvent().getGroup();
           List<GroupMember> groupMembers = group.getGroupMembers();
+          List<ScheduleMember> participants = scheduleMemberRepository.findAllBySchedule(schedule);
           ScheduleMember sm = scheduleMemberRepository
               .findByScheduleIdAndMemberId(schedule.getId(), memberId)
               .orElseThrow(() ->
                   new IllegalStateException("해당 일정에 대한 ScheduleMember가 존재하지 않습니다. scheduleId=" + schedule.getId())
               );
-          return UnifiedScheduleDto.fromService(schedule, group, sm ,groupMembers);
+          return UnifiedScheduleDto.fromService(schedule, group, sm , participants);
         })
         .toList();
 

--- a/src/main/java/com/grepp/spring/app/model/mypage/service/GoogleOAuthService.java
+++ b/src/main/java/com/grepp/spring/app/model/mypage/service/GoogleOAuthService.java
@@ -48,6 +48,7 @@ public class GoogleOAuthService {
         .queryParam("scope", "https://www.googleapis.com/auth/calendar.readonly")
         .queryParam("access_type", "offline")   // refresh_token 받기 위해 필요
         .queryParam("prompt", "consent")        // 매번 refresh_token 강제 발급하려면 필요
+        .encode()
         .build()
         .toUriString();
 

--- a/src/main/java/com/grepp/spring/app/model/mypage/service/MypageService.java
+++ b/src/main/java/com/grepp/spring/app/model/mypage/service/MypageService.java
@@ -153,7 +153,8 @@ public class MypageService {
     Map<String, String> dayToBitMap = resultList.stream()
         .collect(Collectors.toMap(
             FavoriteTimetableDto::getDay,
-            dto -> String.format("%012X", dto.getTimeBit())
+            dto -> String.format("%012X", dto.getTimeBit()),
+            (existing, replacement) -> replacement // 중복되면 마지막 값으로 덮어쓰기 (중복 key 에러 방지)
         ));
 
     return FavoriteTimetableDto.fromDto(dayToBitMap);

--- a/src/main/java/com/grepp/spring/app/model/mypage/service/MypageService.java
+++ b/src/main/java/com/grepp/spring/app/model/mypage/service/MypageService.java
@@ -47,10 +47,6 @@ public class MypageService {
   public FavoriteLocationDto createFavoriteLocation(
       String memberId, CreateFavoritePlaceRequest request) {
 
-    if (memberId == null || memberId.trim().isEmpty()) {
-      throw new MemberNotFoundException(MyPageErrorCode.INVALID_MEMBER_REQUEST);
-    }
-
     // INVALID_FAVORITE_REQUEST, 400  잘못된 즐겨찾기 요청 예외 처리
     if (request == null) {
       throw new InvalidFavoriteRequestException(MyPageErrorCode.INVALID_FAVORITE_REQUEST);

--- a/src/main/java/com/grepp/spring/app/model/schedule/repository/ScheduleMemberRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/schedule/repository/ScheduleMemberRepository.java
@@ -22,6 +22,10 @@ public interface ScheduleMemberRepository extends JpaRepository<ScheduleMember, 
     // 특정 멤버를 ScheduleMember 에서 삭제
     void deleteByMember(Member member);
 
+    // 특정 일정에 특정 멤버가 참여 중인지 확인 + 그 멤버의 참여 상태 가져오기
     Optional<ScheduleMember> findByScheduleIdAndMemberId(Long scheduleId, String memberId);
+
+    // 일정에 참여하는 멤버 조회 (나 포함)
+    List<ScheduleMember> findAllBySchedule(Schedule schedule);
 
 }

--- a/src/main/java/com/grepp/spring/infra/error/mypageAdvice/MyPageExceptionAdvice.java
+++ b/src/main/java/com/grepp/spring/infra/error/mypageAdvice/MyPageExceptionAdvice.java
@@ -21,7 +21,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-@RestControllerAdvice(basePackages = "com.grepp.spring.app.controller.api.mypage")
+@RestControllerAdvice(basePackages = {
+    "com.grepp.spring.app.controller.api.mypage",
+    "com.grepp.spring.app.controller.api.mainpage"
+})
 @Slf4j
 @Order(1)
 public class MyPageExceptionAdvice {

--- a/src/main/resources/jsy.sql
+++ b/src/main/resources/jsy.sql
@@ -16,6 +16,10 @@ VALUES (10002, '헬스 친구', '운동 같이 하는 모임', true, NOW(), NOW(
 INSERT INTO groups (id, name, description, is_grouped, created_at, modified_at)
 VALUES (10003, '비활성 모임', '아직 정식 그룹 아님', false, NOW(), NOW());
 
+-- 그룹 5
+INSERT INTO groups (id, name, description, is_grouped, created_at, modified_at)
+VALUES (10005, '무슨모임인고임', '아아', true, NOW(), NOW());
+
 -- 해당 그룹에 자걸이 추가
 INSERT INTO group_members(id, activated, role, created_at, group_id, modified_at, member_id, group_admin)
 VALUES (10004, true, 'GROUP_MEMBER', NOW(), 10003, NOW(), 'GOOGLE_115434652372556552718', false);
@@ -30,6 +34,9 @@ values (10002, true, 'GROUP_MEMBER', '2025-07-15 00:47:03.635538', 10002, '2025-
 
 insert into group_members(id, role, member_id, group_id, group_admin)
 values (10003, 'GROUP_LEADER', 'GOOGLE_1234', 10001, true);
+
+insert into group_members(id, activated, role, created_at, group_id, modified_at, member_id, group_admin)
+values (10005, true, 'GROUP_LEADER', '2025-07-15 00:47:03.635538', 10005, '2025-07-15 00:47:03.635538', 'GOOGLE_115434652372556552718', true);
 
 -- 그룹 1 일정 이벤트
 insert into events(id, description, max_member, meeting_type, title, group_id, activated)

--- a/src/main/resources/jsy.sql
+++ b/src/main/resources/jsy.sql
@@ -35,8 +35,10 @@ values (10002, true, 'GROUP_MEMBER', '2025-07-15 00:47:03.635538', 10002, '2025-
 insert into group_members(id, role, member_id, group_id, group_admin)
 values (10003, 'GROUP_LEADER', 'GOOGLE_1234', 10001, true);
 
-insert into group_members(id, activated, role, created_at, group_id, modified_at, member_id, group_admin)
-values (10005, true, 'GROUP_LEADER', '2025-07-15 00:47:03.635538', 10005, '2025-07-15 00:47:03.635538', 'GOOGLE_115434652372556552718', true);
+insert into group_members(id, role, activated,created_at, group_id, modified_at, member_id)
+values (10005, 'GROUP_MEMBER',true, '2025-07-15 00:47:03.635538', 10003, '2025-07-15 00:47:03.635538', 'GOOGLE_115434652372556552718');
+
+
 
 -- 그룹 1 일정 이벤트
 insert into events(id, description, max_member, meeting_type, title, group_id, activated)
@@ -45,6 +47,11 @@ values (1,'DOD 이벤트 생성', 10, 'OFFLINE', 'DOD 이벤트', 10001, true);
 -- 그룹 2 일정 이벤트
 insert into events(id, description, max_member, meeting_type, title, group_id, activated)
 values (2,'DOD 이벤트 생성', 5, 'OFFLINE', 'DOD 이벤트', 10002, true);
+
+-- 그룹 3 일정 이벤트 -> 일회성 일정 테스트
+insert into events(id, description, max_member, meeting_type, title, group_id, activated)
+values (3,'합정 일회성 일정 테스트', 2, 'OFFLINE', '일회성 이벤트', 10003, true);
+
 
 -- 오늘 일정
 insert into schedules(id, start_time, end_time, location, meeting_platform, specific_location, status, event_id, activated, description, schedule_name)
@@ -57,9 +64,13 @@ values (2, '2025-08-01 17:30:00','2025-08-02 23:00:00' , '홍대입구역', 'NON
 insert into schedules(id, start_time, end_time, location, meeting_platform, specific_location, status, event_id, activated, description, schedule_name)
 values (3, '2025-07-14 09:00:00','2025-07-17 18:00:00', '온라인', 'ZOOM', '링크 발송 예정', 'FIXED',1,true, '여러날 걸치는 일정', '멀티데이 일정 테스트');
 
+insert into schedules(id, start_time, end_time, location, meeting_platform, specific_location, status, event_id, activated, description, schedule_name)
+values (4, '2025-07-18 17:30:00','2025-07-18 23:00:00' , '합정역', 'NONE', '8번출구 앞', 'FIXED',3, true, '오늘이 날인가?', '모');
 
-INSERT INTO schedule_members (id, schedule_id, member_id)
+
+INSERT INTO schedule_members (id, schedule_id, member_id, activated)
 VALUES
-    (50001, 1, 'GOOGLE_115434652372556552718'),
-    (50002, 2, 'GOOGLE_115434652372556552718'),
-    (50003, 3, 'GOOGLE_115434652372556552718');
+    (50001, 1, 'GOOGLE_115434652372556552718',true),
+    (50002, 2, 'GOOGLE_115434652372556552718',true),
+    (50003, 3, 'GOOGLE_115434652372556552718',true),
+    (50004, 4, 'GOOGLE_115434652372556552718',true);


### PR DESCRIPTION
## ✅ 관련 이슈
- close #150 

## 🛠️ 작업 내용
- 마이페이지 전역 예외 처리기 범위 메인페이지까지 확장 적용
<img width="559" height="167" alt="image" src="https://github.com/user-attachments/assets/0d541c15-33aa-401e-874b-1687d9dbe4de" />

- 그룹 정보 조회 dto 개선
   - GroupDetailDto 에 그룹장 프로필 이미지 필드 추가 (기존에는 UnifiedScheduleDto 에 포함되었음)
- 일정 dto 개선
   - UnifiedScheduleDto 에 일정 참여 멤버 정보 추가 (사용자 본인 포함)
- 메인페이지 서비스 로직
   - ScheduleMember 없을 시 (사용자가 참여한 일정 없을 시) 예외 대신 null 처리
   - 내부 일정/구글 일정 없으면 빈 리스트 반환 (예외 X)

## 📸 스크린샷 (선택)
<img width="1154" height="405" alt="image" src="https://github.com/user-attachments/assets/07e3f2ca-dff9-43db-a8ee-c5b280dc1e12" />
그룹 목록에서 그룹장 프로필 이미지 번호 전달

<img width="1116" height="398" alt="image" src="https://github.com/user-attachments/assets/5fa38c09-0083-4823-9f1a-bb7d1be911e5" />
일정 참여자 목록 전달

## 🧩 기타 참고사항
- 구글 캘린더 연동 방식 변경
  - 기존 구글 캘린더 연동 시에 OAuth + Token 저장하는 방식은 캘린더 공개 범위(scope) 문제와 테스트 사용자에 한정해서 이용 가능한 한계가 있어서 구글 API key + 공개 캘린더 ID 활용하는 방안으로 변경
  - 흐름
  1) 프론트에서 공개 캘린더 ID 전달
  2) 백엔드에서 API key 로 해당 공개 캘린더 조회
  3) 필요한 데이터만 취사선택해서 DB 에 저장 
  4) 프론트로 응답
