### PR TITLE
일정 - 권한관리 로직 추가, 환승정보 '호선', '선' 제거 후 전달, 출발장소 -> 중간장소 결과 재확인, MeetingPlatform 수정, 일정장 에 따른 권한예외, 전역 예외처리

### DIFF
--- a/src/main/java/com/grepp/spring/app/controller/api/external/ExcelUploadController.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/external/ExcelUploadController.java
@@ -1,29 +1,29 @@
-package com.grepp.spring.app.controller.api.external;
-
-import com.grepp.spring.app.model.schedule.service.ExcelUploadService;
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
-
-@RestController
-@RequiredArgsConstructor
-@RequestMapping("/api/excel")
-public class ExcelUploadController {
-
-    private final ExcelUploadService excelUploadService;
-
-    @PostMapping("/upload")
-    public ResponseEntity<String> uploadExcel(@RequestParam("file") MultipartFile file) {
-        try {
-            excelUploadService.importFromExcel(file);
-            return ResponseEntity.ok("Upload Success");
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Upload Failed: " + e.getMessage());
-        }
-    }
-}
+//package com.grepp.spring.app.controller.api.external;
+//
+//import com.grepp.spring.app.model.schedule.service.ExcelUploadService;
+//import lombok.RequiredArgsConstructor;
+//import org.springframework.http.HttpStatus;
+//import org.springframework.http.ResponseEntity;
+//import org.springframework.web.bind.annotation.PostMapping;
+//import org.springframework.web.bind.annotation.RequestMapping;
+//import org.springframework.web.bind.annotation.RequestParam;
+//import org.springframework.web.bind.annotation.RestController;
+//import org.springframework.web.multipart.MultipartFile;
+//
+//@RestController
+//@RequiredArgsConstructor
+//@RequestMapping("/api/excel")
+//public class ExcelUploadController {
+//
+//    private final ExcelUploadService excelUploadService;
+//
+//    @PostMapping("/upload")
+//    public ResponseEntity<String> uploadExcel(@RequestParam("file") MultipartFile file) {
+//        try {
+//            excelUploadService.importFromExcel(file);
+//            return ResponseEntity.ok("Upload Success");
+//        } catch (Exception e) {
+//            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Upload Failed: " + e.getMessage());
+//        }
+//    }
+//}

--- a/src/main/java/com/grepp/spring/app/controller/api/schedule/ScheduleController.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/schedule/ScheduleController.java
@@ -86,7 +86,6 @@ public class ScheduleController {
             return ResponseEntity.ok(ApiResponse.success("일정이 수정되었습니다."));
     }
 
-
     // 일정 삭제
     @Operation(summary = "일정 삭제", description = "일정을 삭제합니다.")
     @DeleteMapping("/delete/{scheduleId}")

--- a/src/main/java/com/grepp/spring/app/controller/api/schedule/ScheduleController.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/schedule/ScheduleController.java
@@ -21,19 +21,13 @@ import com.grepp.spring.app.model.event.entity.Event;
 import com.grepp.spring.app.model.schedule.entity.Location;
 import com.grepp.spring.app.model.schedule.entity.Schedule;
 import com.grepp.spring.app.model.schedule.entity.ScheduleMember;
-import com.grepp.spring.app.model.schedule.repository.LocationQueryRepository;
-import com.grepp.spring.app.model.schedule.repository.ScheduleMemberQueryRepository;
+import com.grepp.spring.app.model.schedule.entity.Workspace;
 import com.grepp.spring.app.model.schedule.service.ScheduleCommandService;
 import com.grepp.spring.app.model.schedule.service.ScheduleQueryService;
-import com.grepp.spring.infra.error.exceptions.AuthApiException;
-import com.grepp.spring.infra.error.exceptions.NotFoundException;
 import com.grepp.spring.infra.response.ApiResponse;
-import com.grepp.spring.infra.response.ResponseCode;
 import io.swagger.v3.oas.annotations.Operation;
-import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -54,11 +48,6 @@ public class ScheduleController {
     private ScheduleCommandService scheduleCommandService;
     @Autowired
     private ScheduleQueryService scheduleQueryService;
-
-    @Autowired
-    private ScheduleMemberQueryRepository scheduleMemberQueryRepository;
-    @Autowired
-    private LocationQueryRepository locationQueryRepository;
 
     // 일정 조회
     @Operation(summary = "일정 조회", description = "일정을 조회합니다.")
@@ -83,19 +72,16 @@ public class ScheduleController {
             CreateSchedulesResponse response = scheduleCommandService.createSchedule(request, event);
 
             return ResponseEntity.ok(ApiResponse.success(response));
-
     }
 
     // 일정 수정
     @Operation(summary = "일정 수정", description = "일정 수정을 진행합니다.")
     @PatchMapping("/modify/{scheduleId}")
-    // 일정 수정 관련된 것들은 모두 수행. Pathch는 리소스 일부 수정만 가능. 바꾸고 싶은 필드만 변경가능
-    // request 전체 내용 중 변경된 내용만 반영해야 한다. 그럼 request의 14개의 필드 null 체크를 다 해줘야 하나...?
     public ResponseEntity<ApiResponse<Void>> modifySchedule(
         @PathVariable Long scheduleId, @RequestBody ModifySchedulesRequest request) {
 
-            scheduleQueryService.findScheduleById(scheduleId);
-            scheduleCommandService.modifySchedule(request, scheduleId);
+            Schedule schedule = scheduleQueryService.findScheduleById(scheduleId);
+            scheduleCommandService.modifySchedule(request, schedule.getId());
 
             return ResponseEntity.ok(ApiResponse.success("일정이 수정되었습니다."));
     }
@@ -107,8 +93,8 @@ public class ScheduleController {
     public ResponseEntity<ApiResponse<DeleteSchedulesResponse>> deleteSchedules(
         @PathVariable Long scheduleId) {
 
-            scheduleQueryService.findScheduleById(scheduleId);
-            scheduleCommandService.deleteSchedule(scheduleId);
+            Schedule schedule = scheduleQueryService.findScheduleById(scheduleId);
+            scheduleCommandService.deleteSchedule(schedule.getId());
 
             return ResponseEntity.ok(ApiResponse.success("일정을 삭제했습니다."));
     }
@@ -121,9 +107,9 @@ public class ScheduleController {
         @RequestParam Long scheduleId, @RequestBody CreateDepartLocationRequest request)
         throws JsonProcessingException {
 
-            scheduleQueryService.findScheduleById(scheduleId);
+            Schedule schedule = scheduleQueryService.findScheduleById(scheduleId);
 
-            scheduleCommandService.createDepartLocation(scheduleId, request);
+            scheduleCommandService.createDepartLocation(schedule.getId(), request);
 
             return ResponseEntity.ok(ApiResponse.success("출발장소가 등록되었습니다."));
     }
@@ -134,8 +120,8 @@ public class ScheduleController {
     public ResponseEntity<ApiResponse<ShowSuggestedLocationsResponse>> showSuggestedLocations(
         @PathVariable Long scheduleId) {
 
-            scheduleQueryService.findScheduleById(scheduleId);
-            ShowSuggestedLocationsResponse response = scheduleQueryService.showSuggestedLocation(scheduleId);
+            Schedule schedule = scheduleQueryService.findScheduleById(scheduleId);
+            ShowSuggestedLocationsResponse response = scheduleQueryService.showSuggestedLocation(schedule.getId());
 
             return ResponseEntity.ok(ApiResponse.success(response));
     }
@@ -157,17 +143,11 @@ public class ScheduleController {
     public ResponseEntity<ApiResponse<VoteMiddleLocationsResponse>> voteMiddleLocation(
         @PathVariable Long scheduleMemberId, @RequestBody VoteMiddleLocationsRequest request) {
 
-            Schedule sId = scheduleQueryService.findScheduleById(request.getScheduleId());
-            Optional<ScheduleMember> smId = scheduleMemberQueryRepository.findById(scheduleMemberId);
-            Optional<Location> lId = locationQueryRepository.findById(request.getLocationId());
+            Schedule schedule = scheduleQueryService.findScheduleById(request.getScheduleId());
+            ScheduleMember scheduleMember = scheduleQueryService.findScheduleMemberById(scheduleMemberId);
+            Location location = scheduleQueryService.findLocationById(request.getLocationId());
 
-            if (lId.isEmpty()) {
-                return ResponseEntity.status(404)
-                    .body(ApiResponse.error(ResponseCode.NOT_FOUND,
-                        "해당 투표리스트(장소)를 찾을 수 없습니다. locationId를 확인해주세요."));
-            }
-
-            scheduleCommandService.voteMiddleLocation(smId, lId, sId);
+            scheduleCommandService.voteMiddleLocation(schedule, scheduleMember, location);
 
             return ResponseEntity.ok(ApiResponse.success("성공적으로 투표를 진행했습니다."));
     }
@@ -200,8 +180,8 @@ public class ScheduleController {
     @PostMapping("/add-workspace/{scheduleId}")
     public ResponseEntity<ApiResponse<CreateWorkspaceResponse>> createWorkspace(@PathVariable Long scheduleId, @RequestBody AddWorkspaceRequest request) {
 
-            Schedule sId = scheduleQueryService.findScheduleById(scheduleId);
-            scheduleCommandService.AddWorkspace(sId, request);
+            Schedule schedule = scheduleQueryService.findScheduleById(scheduleId);
+            scheduleCommandService.AddWorkspace(schedule, request);
 
             return ResponseEntity.ok(ApiResponse.success("워크스페이스를 등록했습니다."));
     }
@@ -209,10 +189,11 @@ public class ScheduleController {
     // 공통 워크스페이스 삭제
     @Operation(summary = "워크스페이스 삭제", description = "워크스페이스 삭제를 진행합니다.")
     @PostMapping("/delete-workspace/{workspaceId}")
-    public ResponseEntity<ApiResponse<DeleteWorkSpaceResponse>> createWorkspace(
-        @PathVariable Long workspaceId) {
+    public ResponseEntity<ApiResponse<DeleteWorkSpaceResponse>> createWorkspace(@PathVariable Long workspaceId) {
 
-            scheduleCommandService.deleteWorkspace(workspaceId);
+        Workspace workspace = scheduleQueryService.findWorkspaceById(workspaceId);
+
+            scheduleCommandService.deleteWorkspace(workspace.getId());
 
             return ResponseEntity.ok(ApiResponse.success("워크스페이스를 삭제했습니다."));
     }

--- a/src/main/java/com/grepp/spring/app/controller/api/schedule/ScheduleController.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/schedule/ScheduleController.java
@@ -60,7 +60,7 @@ public class ScheduleController {
     @Autowired
     private LocationQueryRepository locationQueryRepository;
 
-    // 일정 조회 ㅇ
+    // 일정 조회
     @Operation(summary = "일정 조회", description = "일정을 조회합니다.")
     @GetMapping("/show/{scheduleId}")
     public ResponseEntity<ApiResponse<ShowScheduleResponse>> showSchedules(

--- a/src/main/java/com/grepp/spring/app/controller/api/schedule/payload/request/CreateDepartLocationRequest.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/schedule/payload/request/CreateDepartLocationRequest.java
@@ -6,7 +6,6 @@ import lombok.Setter;
 @Getter
 @Setter
 public class CreateDepartLocationRequest {
-    private String memberId; // 임시
 
     private String departLocationName; // 출발장소 명
     private Double latitude;    // 위도

--- a/src/main/java/com/grepp/spring/app/controller/api/schedule/payload/request/ModifySchedulesRequest.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/schedule/payload/request/ModifySchedulesRequest.java
@@ -19,7 +19,6 @@ public class ModifySchedulesRequest {
     private Double specificLatitude; // 추가
     private Double specificLongitude;  // 추가
     private MeetingPlatform meetingPlatform;
-    private String platformName;
     private String platformURL;
     private ScheduleStatus status;
 

--- a/src/main/java/com/grepp/spring/app/controller/api/schedule/payload/response/ShowScheduleResponse.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/schedule/payload/response/ShowScheduleResponse.java
@@ -35,7 +35,6 @@ public class ShowScheduleResponse {
     private MeetingType meetingType; // 온오프라인여부
 
     private MeetingPlatform meetingPlatform; // ZOOM | GOOGLE_MEET | NONE
-    private String platformName;
     private String platformUrl;
 
     private List<ScheduleMembersDto> members;

--- a/src/main/java/com/grepp/spring/app/controller/api/schedule/payload/response/ShowScheduleResponse.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/schedule/payload/response/ShowScheduleResponse.java
@@ -3,6 +3,7 @@ package com.grepp.spring.app.controller.api.schedule.payload.response;
 import com.grepp.spring.app.model.event.code.MeetingType;
 import com.grepp.spring.app.model.schedule.code.MeetingPlatform;
 import com.grepp.spring.app.model.schedule.code.ScheduleStatus;
+import com.grepp.spring.app.model.schedule.dto.ScheduleMembersDto;
 import com.grepp.spring.app.model.schedule.dto.WorkspaceDto;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -37,7 +38,7 @@ public class ShowScheduleResponse {
     private String platformName;
     private String platformUrl;
 
-    private List<String> members;
+    private List<ScheduleMembersDto> members;
     private List<WorkspaceDto> workspaces;
 
 }

--- a/src/main/java/com/grepp/spring/app/model/schedule/dto/ModifyScheduleDto.java
+++ b/src/main/java/com/grepp/spring/app/model/schedule/dto/ModifyScheduleDto.java
@@ -26,7 +26,6 @@ public class ModifyScheduleDto {
     private Double specificLongitude;  // 추가
 
     private MeetingPlatform meetingPlatform;
-    private String platformName;
     private String platformURL;
     private ScheduleStatus status;
 
@@ -35,6 +34,9 @@ public class ModifyScheduleDto {
     private List<WorkspaceDto> workspaces;
 
     public static ModifyScheduleDto toDto(ModifySchedulesRequest request) {
+        String url = request.getMeetingPlatform().equals(MeetingPlatform.NONE)
+            ? null : request.getPlatformURL();
+
         return ModifyScheduleDto.builder()
             .startTime(request.getStartTime())
             .endTime(request.getEndTime())
@@ -45,8 +47,7 @@ public class ModifyScheduleDto {
             .specificLatitude(request.getSpecificLatitude()) // 추가
             .specificLongitude(request.getSpecificLongitude()) // 추가
             .meetingPlatform(request.getMeetingPlatform())
-            .platformName(request.getPlatformName())
-            .platformURL(request.getPlatformURL())
+            .platformURL(url)
             .status(request.getStatus())
             .workspaceId(request.getWorkspaceId())
             .workspaces(request.getWorkspaces())

--- a/src/main/java/com/grepp/spring/app/model/schedule/dto/ScheduleMembersDto.java
+++ b/src/main/java/com/grepp/spring/app/model/schedule/dto/ScheduleMembersDto.java
@@ -1,0 +1,18 @@
+package com.grepp.spring.app.model.schedule.dto;
+
+import com.grepp.spring.app.model.schedule.code.ScheduleRole;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ScheduleMembersDto {
+    private String name;
+    private ScheduleRole scheduleRole;
+}

--- a/src/main/java/com/grepp/spring/app/model/schedule/dto/ShowScheduleDto.java
+++ b/src/main/java/com/grepp/spring/app/model/schedule/dto/ShowScheduleDto.java
@@ -41,10 +41,7 @@ public class ShowScheduleDto {
     private String scheduleName;
     private String description;
 
-
-
     private MeetingPlatform meetingPlatform; // ZOOM | GOOGLE_MEET | NONE
-    private String platformName;
     private String platformUrl;
 
     private List<ScheduleMembersDto> members;
@@ -65,7 +62,6 @@ public class ShowScheduleDto {
             .scheduleName(dto.getScheduleName())
             .description(dto.getDescription())
             .meetingPlatform(dto.getMeetingPlatform())
-            .platformName(dto.getPlatformName())
             .platformUrl(dto.getPlatformUrl())
             .members(dto.getMembers())
             .workspaces(dto.getWorkspaces())

--- a/src/main/java/com/grepp/spring/app/model/schedule/dto/ShowScheduleDto.java
+++ b/src/main/java/com/grepp/spring/app/model/schedule/dto/ShowScheduleDto.java
@@ -47,7 +47,7 @@ public class ShowScheduleDto {
     private String platformName;
     private String platformUrl;
 
-    private List<String> members;
+    private List<ScheduleMembersDto> members;
     private List<WorkspaceDto> workspaces;
 
     public static ShowScheduleResponse fromDto(ShowScheduleDto dto) {
@@ -72,9 +72,7 @@ public class ShowScheduleDto {
             .build();
     }
 
-    public static ShowScheduleDto fromEntity(MeetingType meetingType, Long event, Schedule schedule,
-
-        List<ScheduleMember> scheduleMembers, List<Workspace> workspace) {
+    public static ShowScheduleDto fromEntity(MeetingType meetingType, Long event, Schedule schedule, List<ScheduleMember> scheduleMembers, List<Workspace> workspace) {
 
         ScheduleStatus scheduleStatus;
 
@@ -86,7 +84,11 @@ public class ShowScheduleDto {
             scheduleStatus = ScheduleStatus.FIXED;
         }
 
-        List<String> members = scheduleMembers.stream().map(ScheduleMember::getName)
+        List<ScheduleMembersDto> members = IntStream.range(0, scheduleMembers.size())
+            .mapToObj(i-> new ScheduleMembersDto(
+                scheduleMembers.get(i).getName(),
+                scheduleMembers.get(i).getRole()
+            ))
             .collect(Collectors.toList());
 
 

--- a/src/main/java/com/grepp/spring/app/model/schedule/repository/ScheduleMemberQueryRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/schedule/repository/ScheduleMemberQueryRepository.java
@@ -22,5 +22,4 @@ public interface ScheduleMemberQueryRepository extends JpaRepository<ScheduleMem
         @Param("scheduleId") Long scheduleId);
 
     ArrayList<ScheduleMember> findBySchedule(Schedule schedule);
-
 }

--- a/src/main/java/com/grepp/spring/app/model/schedule/service/ScheduleCommandService.java
+++ b/src/main/java/com/grepp/spring/app/model/schedule/service/ScheduleCommandService.java
@@ -23,7 +23,10 @@ import com.grepp.spring.app.model.schedule.dto.*;
 import com.grepp.spring.app.model.schedule.entity.*;
 import com.grepp.spring.app.model.schedule.repository.*;
 import com.grepp.spring.infra.error.exceptions.NotFoundException;
+import com.grepp.spring.infra.error.exceptions.group.UserNotFoundException;
+import com.grepp.spring.infra.error.exceptions.schedule.LocationNotFoundException;
 import com.grepp.spring.infra.error.exceptions.schedule.NotScheduleMasterException;
+import com.grepp.spring.infra.response.GroupErrorCode;
 import com.grepp.spring.infra.response.ScheduleErrorCode;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
@@ -46,8 +49,6 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.time.format.DateTimeFormatter;
-import java.util.List;
-import java.util.Optional;
 
 @Service
 @Slf4j
@@ -107,7 +108,7 @@ public class ScheduleCommandService {
             ScheduleRole role = entry.getRole();
 
             Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new NotFoundException("멤버를 찾을 수 없습니다."));
+                .orElseThrow(() -> new UserNotFoundException(GroupErrorCode.USER_NOT_FOUND));
 
             ScheduleMember scheduleMember = ScheduleMember.builder()
                 .name(member.getName())
@@ -122,7 +123,7 @@ public class ScheduleCommandService {
         return CreateScheduleDto.toResponse(schedule.getId());
     }
 
-    @Transactional // JPA 영속성 컨텍스트 변경 감지. setter를 사용해서 값 바꾸면 자동으로 변경
+    @Transactional
     public void modifySchedule(ModifySchedulesRequest request, Long scheduleId) {
 
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
@@ -140,7 +141,6 @@ public class ScheduleCommandService {
             modifyWorkspaceEntity(scheduleId, dto, request.getWorkspaceId());
         }
         else {
-            // ROLE_MASWER 아닐 시 예외처리
             throw new NotScheduleMasterException(ScheduleErrorCode.NOT_SCHEDULE_MASTER);
         }
 
@@ -223,18 +223,16 @@ public class ScheduleCommandService {
         ScheduleMember scheduleMember = scheduleMemberQueryRepository.findScheduleMember(user.getUsername(), scheduleId);
 
         if (scheduleMember.getRole() == ScheduleRole.ROLE_MASTER) {
-            scheduleCommandRepository.deleteById(scheduleId); // 스케줄 삭제
+            scheduleCommandRepository.deleteById(scheduleId);
         }
 
         else {
-            // ROLE_MASWER 아닐 시 예외처리
             throw new NotScheduleMasterException(ScheduleErrorCode.NOT_SCHEDULE_MASTER);
         }
-
     }
 
-    public void AddWorkspace(Schedule scheduleId, AddWorkspaceRequest request) {
-        AddWorkspaceDto dto = AddWorkspaceDto.toDto(scheduleId, request);
+    public void AddWorkspace(Schedule schedule, AddWorkspaceRequest request) {
+        AddWorkspaceDto dto = AddWorkspaceDto.toDto(schedule, request);
         Workspace workspace = AddWorkspaceDto.fromDto(dto);
         workspaceCommandRepository.save(workspace);
     }
@@ -247,15 +245,17 @@ public class ScheduleCommandService {
     public void createDepartLocation(Long scheduleId, CreateDepartLocationRequest request)
         throws JsonProcessingException {
 
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Principal user = (Principal) authentication.getPrincipal();
+
         Optional<Schedule> schedule = scheduleQueryRepository.findById(scheduleId);
 
         // 출발장소 추가될때마다 매번 다른 중간장소가 나와야함. 기존의 중간장소는 모두 삭제
         metroTransferCommandRepository.deleteByScheduleId(scheduleId);
         locationCommandRepository.deleteLocation(scheduleId);
 
-        //임시
         ScheduleMember scheduleMember = scheduleMemberQueryRepository.findScheduleMember(
-            request.getMemberId(), scheduleId);
+            user.getUsername(), scheduleId);
 
         Optional<Metro> metro = metroQueryRepository.findByName(request.getDepartLocationName());
 
@@ -275,7 +275,7 @@ public class ScheduleCommandService {
             scheduleMember.setLatitude(dto.getLatitude());
         }
 
-        //TODO : 출발장소들을 이용하여 중간장소 계산
+        // 출발장소들을 이용하여 중간장소 계산
         List<ScheduleMember> scheduleLocations = scheduleMemberQueryRepository.findByScheduleId(scheduleId);
 
         Double middleLatitude = 0.0;
@@ -294,7 +294,7 @@ public class ScheduleCommandService {
             middleLatitude = middleLatitude / cnt;
             middleLongitude = middleLongitude / cnt;
 
-            // 3개의 지하철역 정보를 가져옴
+            // 3개의 지하철역 정보를 가져오기
             List<JsonNode> subwayStation = findNearestStations(middleLatitude, middleLongitude);
 
             log.info("subwayStation size = {}", subwayStation.size());
@@ -316,7 +316,6 @@ public class ScheduleCommandService {
                 }
             }
         }
-
 
         log.info("middleLatitude = {}", middleLatitude);
         log.info("middleLongitude = {}", middleLongitude);
@@ -375,27 +374,25 @@ public class ScheduleCommandService {
     }
 
     @Transactional
-    public void voteMiddleLocation( Optional<ScheduleMember> scheduleMember , Optional<Location> lid, Schedule schedule) {
+    public void voteMiddleLocation(Schedule schedule, ScheduleMember scheduleMember, Location lid) {
 
-        VoteMiddleLocationDto dto = VoteMiddleLocationDto.toDto(scheduleMember.orElse(null), lid.orElse(null), schedule);
+        VoteMiddleLocationDto dto = VoteMiddleLocationDto.toDto(scheduleMember, lid, schedule);
         Vote vote = VoteMiddleLocationDto.fromDto(dto);
         voteCommandRepository.save(vote);
 
-        Location location = locationQueryRepository
-            .findById(lid.map(Location::getId)
-                .orElseThrow(() -> new IllegalArgumentException("Location ID 없음")))
-            .orElseThrow(() -> new IllegalArgumentException("해당 Location 없음"));
+        Location location = locationQueryRepository.findById(lid.getId())
+            .orElseThrow(() -> new LocationNotFoundException(ScheduleErrorCode.LOCATION_NOT_FOUND));
 
             location.setVoteCount(location.getVoteCount() + 1);
 
-        List<Location> location2 = locationQueryRepository.findByScheduleId(schedule.getId());
+        List<Location> locationList = locationQueryRepository.findByScheduleId(schedule.getId());
         int scheduleMemberNumber = scheduleMemberQueryRepository.findByScheduleId(schedule.getId()).size();
         int voteCount = voteQueryRepository.findByScheduleId(schedule.getId()).size();
 
         if (scheduleMemberNumber - voteCount == 0) {
             int winner = 0;
             Long winnerLid = null;
-            for (Location l : location2) {
+            for (Location l : locationList) {
                 if (winner <= l.getVoteCount()) {
                     winner = l.getVoteCount();
                     winnerLid = l.getId();
@@ -484,7 +481,6 @@ public class ScheduleCommandService {
         }
 
         else {
-            // ROLE_MASWER 아닐 시 예외처리
             throw new NotScheduleMasterException(ScheduleErrorCode.NOT_SCHEDULE_MASTER);
         }
 

--- a/src/main/java/com/grepp/spring/app/model/schedule/service/ScheduleCommandService.java
+++ b/src/main/java/com/grepp/spring/app/model/schedule/service/ScheduleCommandService.java
@@ -23,6 +23,8 @@ import com.grepp.spring.app.model.schedule.dto.*;
 import com.grepp.spring.app.model.schedule.entity.*;
 import com.grepp.spring.app.model.schedule.repository.*;
 import com.grepp.spring.infra.error.exceptions.NotFoundException;
+import com.grepp.spring.infra.error.exceptions.schedule.NotScheduleMasterException;
+import com.grepp.spring.infra.response.ScheduleErrorCode;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import java.util.ArrayList;
@@ -123,11 +125,26 @@ public class ScheduleCommandService {
     @Transactional // JPA 영속성 컨텍스트 변경 감지. setter를 사용해서 값 바꾸면 자동으로 변경
     public void modifySchedule(ModifySchedulesRequest request, Long scheduleId) {
 
-        ModifyScheduleDto dto = ModifyScheduleDto.toDto(request);
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
-        modifyScheduleEntity(scheduleId, dto);
+        Principal user = (Principal) authentication.getPrincipal();
 
-        modifyWorkspaceEntity(scheduleId, dto, request.getWorkspaceId());
+        ScheduleMember scheduleMember = scheduleMemberQueryRepository.findScheduleMember(user.getUsername(), scheduleId);
+
+        if (scheduleMember.getRole() == ScheduleRole.ROLE_MASTER) {
+
+            ModifyScheduleDto dto = ModifyScheduleDto.toDto(request);
+
+            modifyScheduleEntity(scheduleId, dto);
+
+            modifyWorkspaceEntity(scheduleId, dto, request.getWorkspaceId());
+        }
+        else {
+            // ROLE_MASWER 아닐 시 예외처리
+            throw new NotScheduleMasterException(ScheduleErrorCode.NOT_SCHEDULE_MASTER);
+        }
+
+
     }
 
     private void modifyScheduleEntity(Long scheduleId, ModifyScheduleDto dto) {
@@ -199,7 +216,21 @@ public class ScheduleCommandService {
 
     @Transactional
     public void deleteSchedule(Long scheduleId) {
-        scheduleCommandRepository.deleteById(scheduleId); // 스케줄 삭제
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        Principal user = (Principal) authentication.getPrincipal();
+
+        ScheduleMember scheduleMember = scheduleMemberQueryRepository.findScheduleMember(user.getUsername(), scheduleId);
+
+        if (scheduleMember.getRole() == ScheduleRole.ROLE_MASTER) {
+            scheduleCommandRepository.deleteById(scheduleId); // 스케줄 삭제
+        }
+
+        else {
+            // ROLE_MASWER 아닐 시 예외처리
+            throw new NotScheduleMasterException(ScheduleErrorCode.NOT_SCHEDULE_MASTER);
+        }
+
     }
 
     public void AddWorkspace(Schedule scheduleId, AddWorkspaceRequest request) {
@@ -424,29 +455,37 @@ public class ScheduleCommandService {
     public void WriteSuggestedLocation(Schedule schedule, WriteSuggestedLocationRequest request) {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         Principal user = (Principal) auth.getPrincipal();
+        ScheduleMember scheduleMember = scheduleMemberQueryRepository.findScheduleMember(user.getUsername(), schedule.getId());
         Member member = memberRepository.findById(user.getUsername()).orElseThrow();
         Optional<Metro> metro = metroQueryRepository.findByName(request.getLocationName());
 
-        Location location;
-        // DB에 존재하지 않는다면
-        if (metro.isEmpty()) {
-            WriteSuggestedLocationDto dto = WriteSuggestedLocationDto.requestToDto(request, schedule, member);
+        if (scheduleMember.getRole() == ScheduleRole.ROLE_MASTER) {
+            Location location;
+            // DB에 존재하지 않는다면
+            if (metro.isEmpty()) {
+                WriteSuggestedLocationDto dto = WriteSuggestedLocationDto.requestToDto(request, schedule, member);
 
-            location = WriteSuggestedLocationDto.fromDto(dto);
-            location = locationCommandRepository.save(location);
+                location = WriteSuggestedLocationDto.fromDto(dto);
+                location = locationCommandRepository.save(location);
+            }
+            else { // DB에 존재한다면
+                location = WriteSuggestedLocationDto.metroToEntity(metro.get(), schedule, member);
+                location = locationCommandRepository.save(location);
+            }
+
+            metro = metroQueryRepository.findByName(location.getName());
+            List<Line> line = lineQueryRepository.findByMetroId(metro.get().getId());
+
+            for (Line l : line) {
+                WriteSuggestedMetroTransferDto dto =  WriteSuggestedMetroTransferDto.toDto(schedule,location,l);
+                MetroTransfer metroTransfer = WriteSuggestedMetroTransferDto.fromDto(dto);
+                metroTransferCommandRepository.save(metroTransfer);
+            }
         }
-        else { // DB에 존재한다면
-            location = WriteSuggestedLocationDto.metroToEntity(metro.get(), schedule, member);
-            location = locationCommandRepository.save(location);
-        }
 
-        metro = metroQueryRepository.findByName(location.getName());
-        List<Line> line = lineQueryRepository.findByMetroId(metro.get().getId());
-
-        for (Line l : line) {
-            WriteSuggestedMetroTransferDto dto =  WriteSuggestedMetroTransferDto.toDto(schedule,location,l);
-            MetroTransfer metroTransfer = WriteSuggestedMetroTransferDto.fromDto(dto);
-            metroTransferCommandRepository.save(metroTransfer);
+        else {
+            // ROLE_MASWER 아닐 시 예외처리
+            throw new NotScheduleMasterException(ScheduleErrorCode.NOT_SCHEDULE_MASTER);
         }
 
     }

--- a/src/main/java/com/grepp/spring/app/model/schedule/service/ScheduleCommandService.java
+++ b/src/main/java/com/grepp/spring/app/model/schedule/service/ScheduleCommandService.java
@@ -189,9 +189,9 @@ public class ScheduleCommandService {
             schedule.get().setMeetingPlatform(dto.getMeetingPlatform());
         }
 
-        if (dto.getPlatformURL() != null) {
+//        if (dto.getPlatformURL() != null) {
             schedule.get().setPlatformUrl(dto.getPlatformURL());
-        }
+//        }
     }
 
     private void modifyWorkspaceEntity(Long scheduleId, ModifyScheduleDto dto, Long workspaceId) {

--- a/src/main/java/com/grepp/spring/app/model/schedule/service/ScheduleQueryService.java
+++ b/src/main/java/com/grepp/spring/app/model/schedule/service/ScheduleQueryService.java
@@ -6,7 +6,6 @@ import com.grepp.spring.app.controller.api.schedule.payload.response.ShowVoteMem
 import com.grepp.spring.app.model.event.code.MeetingType;
 import com.grepp.spring.app.model.event.entity.Event;
 import com.grepp.spring.app.model.event.repository.EventRepository;
-import com.grepp.spring.app.model.member.entity.Member;
 import com.grepp.spring.app.model.member.repository.MemberRepository;
 import com.grepp.spring.app.model.schedule.dto.MetroInfoDto;
 import com.grepp.spring.app.model.schedule.dto.ShowScheduleDto;
@@ -26,11 +25,14 @@ import com.grepp.spring.app.model.schedule.repository.VoteQueryRepository;
 import com.grepp.spring.app.model.schedule.repository.WorkspaceQueryRepository;
 import com.grepp.spring.infra.error.exceptions.event.EventNotFoundException;
 import com.grepp.spring.infra.error.exceptions.group.ScheduleNotFoundException;
+import com.grepp.spring.infra.error.exceptions.schedule.LocationNotFoundException;
+import com.grepp.spring.infra.error.exceptions.schedule.ScheduleMemberNotFoundException;
+import com.grepp.spring.infra.error.exceptions.schedule.WorkSpaceNotFoundException;
 import com.grepp.spring.infra.response.EventErrorCode;
 import com.grepp.spring.infra.response.GroupErrorCode;
+import com.grepp.spring.infra.response.ScheduleErrorCode;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -60,7 +62,7 @@ public class ScheduleQueryService {
 
     @Transactional
     public ShowScheduleResponse showSchedule(Schedule schedule) {
-        // Lazy init 해결하기 위해서 Transactional 내에서 처리
+
         Long eventId = schedule.getEvent().getId();
 
         List<ScheduleMember> scheduleMembers = scheduleMemberQueryRepository.findByScheduleId(
@@ -140,5 +142,19 @@ public class ScheduleQueryService {
         ShowVoteMembersResponse response = VoteMemberDto.fromDto(voteMemberList);
 
         return response;
+    }
+
+    public Location findLocationById(Long locationId) {
+        return locationQueryRepository.findById(locationId).orElseThrow(() -> new LocationNotFoundException(
+            ScheduleErrorCode.LOCATION_NOT_FOUND));
+    }
+
+    public ScheduleMember findScheduleMemberById(Long scheduleMemberId) {
+        return scheduleMemberQueryRepository.findById(scheduleMemberId).orElseThrow(() -> new ScheduleMemberNotFoundException(
+            ScheduleErrorCode.LOCATION_NOT_FOUND));
+    }
+
+    public Workspace findWorkspaceById(Long workspaceId) {
+        return workspaceQueryRepository.findById(workspaceId).orElseThrow(() -> new WorkSpaceNotFoundException(ScheduleErrorCode.WORKSPACE_NOT_FOUND));
     }
 }

--- a/src/main/java/com/grepp/spring/app/model/schedule/service/ScheduleQueryService.java
+++ b/src/main/java/com/grepp/spring/app/model/schedule/service/ScheduleQueryService.java
@@ -96,7 +96,7 @@ public class ScheduleQueryService {
 
         int departLocationCount = 0;
         for (ScheduleMember scheduleMember : scheduleMembers) {
-            if (scheduleMember.getDepartLocationName() != null) {
+            if (scheduleMember.getLatitude() != null) {
                 departLocationCount++;
             }
         }

--- a/src/main/java/com/grepp/spring/infra/error/exceptions/schedule/LocationNotFoundException.java
+++ b/src/main/java/com/grepp/spring/infra/error/exceptions/schedule/LocationNotFoundException.java
@@ -1,0 +1,24 @@
+package com.grepp.spring.infra.error.exceptions.schedule;
+
+import com.grepp.spring.infra.response.ScheduleErrorCode;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class LocationNotFoundException extends RuntimeException {
+
+    private final ScheduleErrorCode code;
+
+    public LocationNotFoundException(ScheduleErrorCode code) {
+        this.code = code;
+    }
+
+    public LocationNotFoundException(ScheduleErrorCode code, Exception e) {
+        this.code = code;
+        log.error(e.getMessage(), e);
+    }
+
+    public ScheduleErrorCode code() {
+        return code;
+    }
+
+}

--- a/src/main/java/com/grepp/spring/infra/error/exceptions/schedule/NotScheduleMasterException.java
+++ b/src/main/java/com/grepp/spring/infra/error/exceptions/schedule/NotScheduleMasterException.java
@@ -1,0 +1,22 @@
+package com.grepp.spring.infra.error.exceptions.schedule;
+
+import com.grepp.spring.infra.response.ScheduleErrorCode;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class NotScheduleMasterException extends RuntimeException{
+    private final ScheduleErrorCode code;
+
+    public NotScheduleMasterException(ScheduleErrorCode code) {
+        this.code = code;
+    }
+
+    public NotScheduleMasterException(ScheduleErrorCode code, Exception e) {
+        this.code = code;
+        log.error(e.getMessage(), e);
+    }
+
+    public ScheduleErrorCode code() {
+        return code;
+    }
+}

--- a/src/main/java/com/grepp/spring/infra/error/exceptions/schedule/ScheduleMemberNotFoundException.java
+++ b/src/main/java/com/grepp/spring/infra/error/exceptions/schedule/ScheduleMemberNotFoundException.java
@@ -1,0 +1,22 @@
+package com.grepp.spring.infra.error.exceptions.schedule;
+
+import com.grepp.spring.infra.response.ScheduleErrorCode;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class ScheduleMemberNotFoundException extends RuntimeException {
+    private final ScheduleErrorCode code;
+
+    public ScheduleMemberNotFoundException(ScheduleErrorCode code) {
+        this.code = code;
+    }
+
+    public ScheduleMemberNotFoundException(ScheduleErrorCode code, Exception e) {
+        this.code = code;
+        log.error(e.getMessage(), e);
+    }
+
+    public ScheduleErrorCode code() {
+        return code;
+    }
+}

--- a/src/main/java/com/grepp/spring/infra/error/exceptions/schedule/WorkSpaceNotFoundException.java
+++ b/src/main/java/com/grepp/spring/infra/error/exceptions/schedule/WorkSpaceNotFoundException.java
@@ -1,0 +1,22 @@
+package com.grepp.spring.infra.error.exceptions.schedule;
+
+import com.grepp.spring.infra.response.ScheduleErrorCode;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class WorkSpaceNotFoundException extends RuntimeException {
+    private final ScheduleErrorCode code;
+
+    public WorkSpaceNotFoundException(ScheduleErrorCode code) {
+        this.code = code;
+    }
+
+    public WorkSpaceNotFoundException(ScheduleErrorCode code, Exception e) {
+        this.code = code;
+        log.error(e.getMessage(), e);
+    }
+
+    public ScheduleErrorCode code() {
+        return code;
+    }
+}

--- a/src/main/java/com/grepp/spring/infra/error/scheduleAdvuce/ScheduleExceptionAdvice.java
+++ b/src/main/java/com/grepp/spring/infra/error/scheduleAdvuce/ScheduleExceptionAdvice.java
@@ -1,10 +1,12 @@
 package com.grepp.spring.infra.error.scheduleAdvuce;
 
-
 import com.grepp.spring.infra.error.exceptions.event.EventNotFoundException;
 import com.grepp.spring.infra.error.exceptions.group.ScheduleNotFoundException;
 import com.grepp.spring.infra.error.exceptions.group.UserNotFoundException;
+import com.grepp.spring.infra.error.exceptions.schedule.LocationNotFoundException;
 import com.grepp.spring.infra.error.exceptions.schedule.NotScheduleMasterException;
+import com.grepp.spring.infra.error.exceptions.schedule.ScheduleMemberNotFoundException;
+import com.grepp.spring.infra.error.exceptions.schedule.WorkSpaceNotFoundException;
 import com.grepp.spring.infra.response.ApiResponse;
 import com.grepp.spring.infra.response.EventErrorCode;
 import com.grepp.spring.infra.response.GroupErrorCode;
@@ -21,49 +23,21 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @Order(1)
 public class ScheduleExceptionAdvice {
 
-//    //403
-//    @ExceptionHandler(NotGroupLeaderException.class)
-//    public ResponseEntity<ApiResponse<String>> notGroupLeaderExHandler(
-//        NotGroupLeaderException ex) {
-//
-//        return ResponseEntity.status(HttpStatus.FORBIDDEN)
-//            .body(ApiResponse.error(GroupErrorCode.NOT_GROUP_LEADER));
-//    }
-//
-//    @ExceptionHandler(NotGroupUserException.class)
-//    public ResponseEntity<ApiResponse<String>> notGroupUserExHandler(
-//        NotGroupUserException ex) {
-//
-//        return ResponseEntity.status(HttpStatus.FORBIDDEN)
-//            .body(ApiResponse.error(GroupErrorCode.NOT_GROUP_MEMBER));
-//    }
-//
-//    @ExceptionHandler(NotScheduleLeaderException.class)
-//    public ResponseEntity<ApiResponse<String>> notScheduleLeaderExHandler(
-//        NotScheduleLeaderException ex) {
-//
-//        return ResponseEntity.status(HttpStatus.FORBIDDEN)
-//            .body(ApiResponse.error(GroupErrorCode.NOT_SCHEDULE_LEADER));
-//    }
-//
-//    @ExceptionHandler(NotScheduleUserException.class)
-//    public ResponseEntity<ApiResponse<String>> notScheduleUserExHandler(
-//        NotScheduleUserException ex) {
-//
-//        return ResponseEntity.status(HttpStatus.FORBIDDEN)
-//            .body(ApiResponse.error(GroupErrorCode.NOT_SCHEDULE_MEMBER));
-//    }
-//
-//
-//    // 404
-//    @ExceptionHandler(GroupNotFoundException.class)
-//    public ResponseEntity<ApiResponse<String>> groupNotFoundExHandler(
-//        GroupNotFoundException ex) {
-//        log.error("404예외");
-//
-//        return ResponseEntity.status(ResponseCode.NOT_FOUND.status())
-//            .body(ApiResponse.error(GroupErrorCode.GROUP_NOT_FOUND));
-//    }
+    @ExceptionHandler(WorkSpaceNotFoundException.class)
+    public ResponseEntity<ApiResponse<String>> workspaceNotFoundExHandler(
+        UserNotFoundException ex) {
+
+        return ResponseEntity.status(ResponseCode.NOT_FOUND.status())
+            .body(ApiResponse.error(ScheduleErrorCode.SCHEDULE_MEMBER_NOT_FOUND));
+    }
+
+    @ExceptionHandler(ScheduleMemberNotFoundException.class)
+    public ResponseEntity<ApiResponse<String>> scheduleMemberNotFoundExHandler(
+        UserNotFoundException ex) {
+
+        return ResponseEntity.status(ResponseCode.NOT_FOUND.status())
+            .body(ApiResponse.error(ScheduleErrorCode.SCHEDULE_MEMBER_NOT_FOUND));
+    }
 
     @ExceptionHandler(UserNotFoundException.class)
     public ResponseEntity<ApiResponse<String>> userNotFoundExHandler(
@@ -71,6 +45,14 @@ public class ScheduleExceptionAdvice {
 
         return ResponseEntity.status(ResponseCode.NOT_FOUND.status())
             .body(ApiResponse.error(GroupErrorCode.USER_NOT_FOUND));
+    }
+
+    @ExceptionHandler(LocationNotFoundException.class)
+    public ResponseEntity<ApiResponse<String>> locationNotFoundExHandler(
+        ScheduleNotFoundException ex) {
+
+        return ResponseEntity.status(ResponseCode.NOT_FOUND.status())
+            .body(ApiResponse.error(GroupErrorCode.SCHEDULE_NOT_FOUND));
     }
 
     @ExceptionHandler(ScheduleNotFoundException.class)
@@ -94,48 +76,6 @@ public class ScheduleExceptionAdvice {
         NotScheduleMasterException ex
     ) {
         return ResponseEntity.status(ResponseCode.NOT_FOUND.status()).
-        body(ApiResponse.error(ScheduleErrorCode.NOT_SCHEDULE_MASTER));
+            body(ApiResponse.error(ScheduleErrorCode.NOT_SCHEDULE_MASTER));
     }
-//
-//    @ExceptionHandler(UserNotInGroupException.class)
-//    public ResponseEntity<ApiResponse<String>> userNotInGroupExHandler(
-//        UserNotInGroupException ex) {
-//
-//        return ResponseEntity.status(ResponseCode.NOT_FOUND.status())
-//            .body(ApiResponse.error(GroupErrorCode.USER_NOT_IN_GROUP));
-//    }
-//
-//
-//    // 409
-//    @ExceptionHandler(UserAlreadyInGroupException.class)
-//    public ResponseEntity<ApiResponse<String>> userAlreadyExHandler(
-//        UserAlreadyInGroupException ex) {
-//
-//        return ResponseEntity.status(ResponseCode.NOT_FOUND.status())
-//            .body(ApiResponse.error(GroupErrorCode.USER_ALREADY_IN_GROUP));
-//    }
-//
-//    @ExceptionHandler(ScheduleAlreadyInGroupException.class)
-//    public ResponseEntity<ApiResponse<String>> scheduleAlreadyExHandler(
-//        ScheduleAlreadyInGroupException ex) {
-//
-//        return ResponseEntity.status(ResponseCode.NOT_FOUND.status())
-//            .body(ApiResponse.error(GroupErrorCode.SCHEDULE_ALREADY_IN_GROUP));
-//    }
-//
-//    @ExceptionHandler(OnlyOneGroupLeaderException.class)
-//    public ResponseEntity<ApiResponse<String>> onlyOneGroupLeaderExHandler(
-//        OnlyOneGroupLeaderException ex) {
-//
-//        return ResponseEntity.status(ResponseCode.NOT_FOUND.status())
-//            .body(ApiResponse.error(GroupErrorCode.ONE_GROUP_LEADER));
-//    }
-//
-//    @ExceptionHandler(UserGroupLeaderException.class)
-//    public ResponseEntity<ApiResponse<String>> userIsGroupLeaderExHandler(
-//        UserGroupLeaderException ex) {
-//
-//        return ResponseEntity.status(ResponseCode.NOT_FOUND.status())
-//            .body(ApiResponse.error(GroupErrorCode.USER_GROUP_LEADER));
-//    }
 }

--- a/src/main/java/com/grepp/spring/infra/error/scheduleAdvuce/ScheduleExceptionAdvice.java
+++ b/src/main/java/com/grepp/spring/infra/error/scheduleAdvuce/ScheduleExceptionAdvice.java
@@ -4,10 +4,12 @@ package com.grepp.spring.infra.error.scheduleAdvuce;
 import com.grepp.spring.infra.error.exceptions.event.EventNotFoundException;
 import com.grepp.spring.infra.error.exceptions.group.ScheduleNotFoundException;
 import com.grepp.spring.infra.error.exceptions.group.UserNotFoundException;
+import com.grepp.spring.infra.error.exceptions.schedule.NotScheduleMasterException;
 import com.grepp.spring.infra.response.ApiResponse;
 import com.grepp.spring.infra.response.EventErrorCode;
 import com.grepp.spring.infra.response.GroupErrorCode;
 import com.grepp.spring.infra.response.ResponseCode;
+import com.grepp.spring.infra.response.ScheduleErrorCode;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.ResponseEntity;
@@ -85,6 +87,14 @@ public class ScheduleExceptionAdvice {
     ) {
         return ResponseEntity.status(ResponseCode.NOT_FOUND.status()).
             body(ApiResponse.error(EventErrorCode.EVENT_NOT_FOUND));
+    }
+
+    @ExceptionHandler(NotScheduleMasterException.class)
+    public ResponseEntity<ApiResponse<String>> notScheduleMasterHandler(
+        NotScheduleMasterException ex
+    ) {
+        return ResponseEntity.status(ResponseCode.NOT_FOUND.status()).
+        body(ApiResponse.error(ScheduleErrorCode.NOT_SCHEDULE_MASTER));
     }
 //
 //    @ExceptionHandler(UserNotInGroupException.class)

--- a/src/main/java/com/grepp/spring/infra/response/ApiResponse.java
+++ b/src/main/java/com/grepp/spring/infra/response/ApiResponse.java
@@ -69,4 +69,12 @@ public record ApiResponse<T>(
     public static <T> ApiResponse<T> error(MyPageErrorCode code, T data) {
         return new ApiResponse<>(code.code(), code.message(), data);
     }
+
+    public static <T> ApiResponse<T> error(ScheduleErrorCode code) {
+        return new ApiResponse<>(code.code(), code.message(), null);
+    }
+
+    public static <T> ApiResponse<T> error(ScheduleErrorCode code, T data) {
+        return new ApiResponse<>(code.code(), code.message(), data);
+    }
 }

--- a/src/main/java/com/grepp/spring/infra/response/ScheduleErrorCode.java
+++ b/src/main/java/com/grepp/spring/infra/response/ScheduleErrorCode.java
@@ -3,19 +3,10 @@ package com.grepp.spring.infra.response;
 import org.springframework.http.HttpStatus;
 
 public enum ScheduleErrorCode {
-//    NOT_GROUP_LEADER("403", HttpStatus.FORBIDDEN,"해당 그룹의 그룹장이 아닙니다. 권한을 확인해주세요"),
-//    NOT_GROUP_MEMBER("403", HttpStatus.FORBIDDEN,"해당 그룹의 그룹원이 아닙니다. 권한을 확인해주세요"),
-    NOT_SCHEDULE_LEADER("403", HttpStatus.FORBIDDEN,"해당 일정의 팀장이 아닙니다. 권한을 확인해주세요"),
-    NOT_SCHEDULE_MEMBER("403", HttpStatus.FORBIDDEN,"해당 일정의 구성원이 아닙니다. 권한을 확인해주세요"),
-//    GROUP_NOT_FOUND("404", HttpStatus.NOT_FOUND,"존재하지 않는 그룹입니다."),
-    USER_NOT_FOUND("404", HttpStatus.NOT_FOUND,"존재하지 않는 유저입니다."),
-    NOT_SCHEDULE_MASTER("404", HttpStatus.NOT_FOUND, "❌권한 이슈❌ ROLE_MASTER 계정만 가능한 작업입니다.");
-//    SCHEDULE_NOT_FOUND("404", HttpStatus.NOT_FOUND,"존재하지 않는 일정입니다."),
-//    USER_NOT_IN_GROUP("404", HttpStatus.NOT_FOUND,"유저가 해당 그룹에 포함되어 있지 않습니다."),
-//    SCHEDULE_ALREADY_IN_GROUP("409", HttpStatus.CONFLICT,"이미 그룹에 존재한 일정입니다."),
-//    USER_ALREADY_IN_GROUP("409", HttpStatus.CONFLICT,"이미 그룹에 존재한 유저입니다."),
-//    ONE_GROUP_LEADER("409", HttpStatus.CONFLICT,"그룹 내 유일한 그룹장입니다. 그룹원에게 그룹장 권한을 부여해주세요."),
-//    USER_GROUP_LEADER("409", HttpStatus.CONFLICT, "해당 유저는 그룹 내의 그룹장입니다. 그룹장은 내보낼 수 없습니다.");
+    NOT_SCHEDULE_MASTER("404", HttpStatus.NOT_FOUND, "❌권한 이슈❌ ROLE_MASTER 계정만 가능한 작업입니다."),
+    LOCATION_NOT_FOUND("404",HttpStatus.NOT_FOUND, "해당 투표리스트(장소)를 찾을 수 없습니다. locationId를 확인해주세요."),
+    SCHEDULE_MEMBER_NOT_FOUND("404",HttpStatus.NOT_FOUND, "스케줄에서 회원을 찾을 수 없습니다."),
+    WORKSPACE_NOT_FOUND("404",HttpStatus.NOT_FOUND,"워크스페이스를 찾을 수 없습니다.");
 
     private final String code;
     private final HttpStatus status;

--- a/src/main/java/com/grepp/spring/infra/response/ScheduleErrorCode.java
+++ b/src/main/java/com/grepp/spring/infra/response/ScheduleErrorCode.java
@@ -8,7 +8,8 @@ public enum ScheduleErrorCode {
     NOT_SCHEDULE_LEADER("403", HttpStatus.FORBIDDEN,"해당 일정의 팀장이 아닙니다. 권한을 확인해주세요"),
     NOT_SCHEDULE_MEMBER("403", HttpStatus.FORBIDDEN,"해당 일정의 구성원이 아닙니다. 권한을 확인해주세요"),
 //    GROUP_NOT_FOUND("404", HttpStatus.NOT_FOUND,"존재하지 않는 그룹입니다."),
-    USER_NOT_FOUND("404", HttpStatus.NOT_FOUND,"존재하지 않는 유저입니다.");
+    USER_NOT_FOUND("404", HttpStatus.NOT_FOUND,"존재하지 않는 유저입니다."),
+    NOT_SCHEDULE_MASTER("404", HttpStatus.NOT_FOUND, "❌권한 이슈❌ ROLE_MASTER 계정만 가능한 작업입니다.");
 //    SCHEDULE_NOT_FOUND("404", HttpStatus.NOT_FOUND,"존재하지 않는 일정입니다."),
 //    USER_NOT_IN_GROUP("404", HttpStatus.NOT_FOUND,"유저가 해당 그룹에 포함되어 있지 않습니다."),
 //    SCHEDULE_ALREADY_IN_GROUP("409", HttpStatus.CONFLICT,"이미 그룹에 존재한 일정입니다."),

--- a/src/main/resources/lkh.sql
+++ b/src/main/resources/lkh.sql
@@ -33,43 +33,43 @@ values (2, '2025-11-11 17:30:00','2025-11-11 23:00:00' , '홍대입구역', 'GOO
 
 -- 멤버 테이블 생성
 insert into members(id, password, provider, role, email, name, profile_image_number, tel)
-values ('1a', 'google', 'GOOGLE', 'ROLE_USER', 'a@mail.com','이서준', 1, '010-1111-1111');
+values ('1a', '{noop}123qwe!@#', 'GOOGLE', 'ROLE_USER', 'a@gmail.com','이서준', 1, '010-1111-1111');
 
 insert into members(id, password, provider, role, email, name, profile_image_number, tel)
-values ('2a', 'google', 'GOOGLE', 'ROLE_USER', 'x@mail.com','이강현', 1, '010-1111-1112');
+values ('2a', '{noop}123qwe!@#', 'GOOGLE', 'ROLE_USER', 'x@gmail.com','이강현', 1, '010-1111-1112');
 
 insert into members(id, password, provider, role, email, name, profile_image_number, tel)
-values ('3a', 'google', 'GOOGLE', 'ROLE_USER', 'b@mail.com','안준희', 1, '010-1111-1113');
+values ('3a', '{noop}123qwe!@#', 'GOOGLE', 'ROLE_USER', 'b@gmail.com','안준희', 1, '010-1111-1113');
 
 insert into members(id, password, provider, role, email, name, profile_image_number, tel)
-values ('4a', 'google', 'GOOGLE', 'ROLE_USER', 'c@mail.com','정서윤', 1, '010-1111-1114');
+values ('4a', '{noop}123qwe!@#', 'GOOGLE', 'ROLE_USER', 'c@gmail.com','정서윤', 1, '010-1111-1114');
 
 insert into members(id, password, provider, role, email, name, profile_image_number, tel)
-values ('5a', 'google', 'GOOGLE', 'ROLE_USER', 'd@mail.com','최동준', 1, '010-1111-1115');
+values ('5a', '{noop}123qwe!@#', 'GOOGLE', 'ROLE_USER', 'd@gmail.com','최동준', 1, '010-1111-1115');
 
 insert into members(id, password, provider, role, email, name, profile_image_number, tel)
-values ('6a', 'google', 'GOOGLE', 'ROLE_USER', 'e@mail.com','박상윤', 1, '010-1111-1116');
+values ('6a', '{noop}123qwe!@#', 'GOOGLE', 'ROLE_USER', 'e@gmail.com','박상윤', 1, '010-1111-1116');
 
 insert into members(id, password, provider, role, email, name, profile_image_number, tel)
-values ('7a', 'google', 'GOOGLE', 'ROLE_USER', 'f@mail.com','박은서', 1, '010-1111-1117');
+values ('7a', '{noop}123qwe!@#', 'GOOGLE', 'ROLE_USER', 'f@gmail.com','박은서', 1, '010-1111-1117');
 
 insert into members(id, password, provider, role, email, name, profile_image_number, tel)
-values ('8a', 'google', 'GOOGLE', 'ROLE_USER', 'g@mail.com','박준규', 1, '010-1111-1118');
+values ('8a', '{noop}123qwe!@#', 'GOOGLE', 'ROLE_USER', 'g@gmail.com','박준규', 1, '010-1111-1118');
 
 insert into members(id, password, provider, role, email, name, profile_image_number, tel)
-values ('9a', 'google', 'GOOGLE', 'ROLE_USER', 'h@mail.com','현혜주', 1, '010-1111-1119');
+values ('9a', '{noop}123qwe!@#', 'GOOGLE', 'ROLE_USER', 'h@gmail.com','현혜주', 1, '010-1111-1119');
 
 insert into members(id, password, provider, role, email, name, profile_image_number, tel)
-values ('10a', 'google', 'GOOGLE', 'ROLE_USER', 'i@mail.com','황수지', 1, '010-1111-1121');
+values ('10a', '{noop}123qwe!@#', 'GOOGLE', 'ROLE_USER', 'i@gmail.com','황수지', 1, '010-1111-1121');
 
 insert into members(id, password, provider, role, email, name, profile_image_number, tel)
-values ('11a', 'google', 'GOOGLE', 'ROLE_USER', 'j@mail.com','홍길동', 1, '010-1111-1131');
+values ('11a', '{noop}123qwe!@#', 'GOOGLE', 'ROLE_USER', 'j@gmail.com','홍길동', 1, '010-1111-1131');
 
 insert into members(id, password, provider, role, email, name, profile_image_number, tel)
-values ('12a', 'google', 'GOOGLE', 'ROLE_USER', 'k@mail.com','길동이', 1, '010-1111-1141');
+values ('12a', '{noop}123qwe!@#', 'GOOGLE', 'ROLE_USER', 'k@gmail.com','길동이', 1, '010-1111-1141');
 
 insert into members(id, password, provider, role, email, name, profile_image_number, tel)
-values ('13a', 'google', 'GOOGLE', 'ROLE_USER', 'z@mail.com','해리포터', 1, '010-1111-5111');
+values ('13a', '{noop}123qwe!@#', 'GOOGLE', 'ROLE_USER', 'z@gmail.com','해리포터', 1, '010-1111-5111');
 
 -- schedule_member 테이블 생성
 insert into schedule_members(id, member_id, schedule_id, role, depart_location_name, latitude, longitude, name)


### PR DESCRIPTION
## ✅ 관련 이슈
- close #158 
- close #161
- close #144 

## 🛠️ 작업 내용
- 일정 조회 시 scheduleRole 함께 반환
- 일정 수정 시 ROLE_MASTER만 변경하도록 로직 변경
- 일정 삭제 시 ROLE_MASTER만 삭제가능하도록 로직 변경
- 투표 전 중간장소 등록 ROLE_MASWER만 가능하도록 변경
- ROLE_MASTER 아닐 시 예외처리 추가
- 환승정보 '호선', '선' 제거 후 전달
- 출발장소 -> 중간장소 결과 재확인
- MeetingPlatform 수정 시 platformUrl null로 변경
- 일정장 권한관리
- 전역 예외처리

## 📸 스크린샷
- 권한 처리
<img width="1539" height="450" alt="image" src="https://github.com/user-attachments/assets/281cef40-0ab6-4dcb-899f-1a806d563049" />

- 멤버 role 함께 제공
<img width="1535" height="540" alt="image" src="https://github.com/user-attachments/assets/1327924d-9fd9-41b4-a703-63854b023bb9" />

- 환승정보 '호선', '선' 제거 후 전달
<img width="1395" height="485" alt="image" src="https://github.com/user-attachments/assets/5dd53368-4905-483c-87b7-284a08fff01d" />

- MeetingPlatform 수정 시 platformUrl null로 변경
<img width="271" height="73" alt="image" src="https://github.com/user-attachments/assets/dcf0aaab-3f33-4b14-b510-ca6261617f06" />

<img width="206" height="33" alt="image" src="https://github.com/user-attachments/assets/42cd7e79-d032-4d3d-bfb7-88b8edb07651" />

- 일정장 권한관리
<img width="1543" height="209" alt="image" src="https://github.com/user-attachments/assets/022d451c-9f05-4aa7-99f7-9c2a347bdb41" />




## 🧩 기타 참고사항
- line DB 값 수정
