### PR TITLE
✨ feat: 로그인 시 클라이언트 지정 uri로 이동하는 기능 구현 완료

### DIFF
--- a/src/main/java/com/grepp/spring/infra/auth/oauth2/CookieAuthorizationRequestRepository.java
+++ b/src/main/java/com/grepp/spring/infra/auth/oauth2/CookieAuthorizationRequestRepository.java
@@ -1,0 +1,55 @@
+package com.grepp.spring.infra.auth.oauth2;
+
+import com.nimbusds.oauth2.sdk.util.StringUtils;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class CookieAuthorizationRequestRepository implements AuthorizationRequestRepository {
+
+    public static final String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "oauth2_auth_request";
+    public static final String REDIRECT_URI_PARAM_COOKIE_NAME = "redirect_uri";
+    private static final int COOKIE_EXPIRE_SECONDS = 180;
+
+    // 쿠키로부터 요청 정보를 가져오기
+    @Override
+    public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+        return CookieUtils.getCookie(request, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)
+            .map(cookie -> CookieUtils.deserialize(cookie, OAuth2AuthorizationRequest.class))
+            .orElse(null);
+    }
+
+    // 인증 정보를 쿠키에 저장
+    @Override
+    public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, HttpServletRequest request, HttpServletResponse response) {
+        if (authorizationRequest == null) {
+            CookieUtils.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+            CookieUtils.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
+            return;
+        }
+
+        CookieUtils.addCookie(response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME, CookieUtils.serialize(authorizationRequest), COOKIE_EXPIRE_SECONDS);
+        String redirectUriAfterLogin = request.getParameter(REDIRECT_URI_PARAM_COOKIE_NAME);
+
+
+        if (StringUtils.isNotBlank(redirectUriAfterLogin)) {
+            CookieUtils.addCookie(response, REDIRECT_URI_PARAM_COOKIE_NAME, redirectUriAfterLogin, COOKIE_EXPIRE_SECONDS);
+        }
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request, HttpServletResponse response) {
+        return this.loadAuthorizationRequest(request);
+    }
+
+    // 쿠키에 담긴 정보 지우기
+    public void removeAuthorizationRequestCookies(HttpServletRequest request, HttpServletResponse response) {
+        CookieUtils.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+        CookieUtils.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
+    }
+}

--- a/src/main/java/com/grepp/spring/infra/auth/oauth2/CookieUtils.java
+++ b/src/main/java/com/grepp/spring/infra/auth/oauth2/CookieUtils.java
@@ -1,0 +1,68 @@
+package com.grepp.spring.infra.auth.oauth2;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Optional;
+import org.springframework.util.SerializationUtils;
+
+public class CookieUtils {
+
+    // 쿠키 가져오기
+    public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null && cookies.length > 0) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals(name)) {
+                    return Optional.of(cookie);
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    // 쿠키 읽기
+    public static Optional<String> readServletCookie(HttpServletRequest request, String name) {
+        return Arrays.stream(request.getCookies())
+            .filter(cookie -> name.equals(cookie.getName()))
+            .map(Cookie::getValue)
+            .findAny();
+    }
+
+    // 쿠키 추가하기
+    public static void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setMaxAge(maxAge);
+        response.addCookie(cookie);
+    }
+
+    // 쿠키 삭제하기
+    public static void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null && cookies.length > 0) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals(name)) {
+                    cookie.setValue("");
+                    cookie.setPath("/");
+                    cookie.setMaxAge(0);
+                    response.addCookie(cookie);
+                }
+            }
+        }
+    }
+
+    // 쿠키에 인증 관련 정보를 직렬화하여 저장하기 위한 메소드
+    public static String serialize(Object object) {
+        return Base64.getUrlEncoder()
+            .encodeToString(SerializationUtils.serialize(object));
+    }
+
+    // 쿠키에서 정보를 역직렬화하여 읽기 위한 메소드
+    public static <T> T deserialize(Cookie cookie, Class<T> cls) {
+        return cls.cast(SerializationUtils.deserialize(Base64.getUrlDecoder().decode(cookie.getValue())));
+    }
+}

--- a/src/main/java/com/grepp/spring/infra/config/security/SecurityConfig.java
+++ b/src/main/java/com/grepp/spring/infra/config/security/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.grepp.spring.infra.config.security;
 import com.grepp.spring.infra.auth.jwt.JwtAuthenticationEntryPoint;
 import com.grepp.spring.infra.auth.jwt.filter.JwtAuthenticationFilter;
 import com.grepp.spring.infra.auth.jwt.filter.JwtExceptionFilter;
+import com.grepp.spring.infra.auth.oauth2.CookieAuthorizationRequestRepository;
 import com.grepp.spring.infra.auth.oauth2.OAuth2FailureHandler;
 import com.grepp.spring.infra.auth.oauth2.OAuth2SuccessHandler;
 import lombok.RequiredArgsConstructor;
@@ -32,6 +33,7 @@ public class SecurityConfig {
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final OAuth2SuccessHandler oAuth2SuccessHandler;
     private final OAuth2FailureHandler oAuth2FailureHandler;
+    private final CookieAuthorizationRequestRepository cookieAuthorizationRequestRepository;
     
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -41,7 +43,11 @@ public class SecurityConfig {
             .httpBasic(AbstractHttpConfigurer::disable)
             .cors(Customizer.withDefaults())
             .oauth2Login(oauth ->
-                oauth.successHandler(oAuth2SuccessHandler)
+                oauth
+                    .authorizationEndpoint(authorization -> authorization
+                        .authorizationRequestRepository(cookieAuthorizationRequestRepository)
+                    )
+                    .successHandler(oAuth2SuccessHandler)
                     .failureHandler(oAuth2FailureHandler)
             )
             .sessionManagement(


### PR DESCRIPTION
## ✅ 관련 이슈
- close #155 

## 🛠️ 작업 내용
- Spring Security의 Oauth2 인증과정에서 필요한 인가정보를 쿠키에 저장할 수 있는 인터페이스 구현체를 작성
- HTTP 쿠키를 사용하도록 돕는 유틸리티 메서드 작성
- Oauth2 인증 완료 시 쿠키로부터 redirect uri를 가져와 검증 및 redirect 하도록 기존 Handler 로직 수정
- 커스텀 인터페이스가 적용되도록 Security Config 옵션 설정

## 📸 스크린샷 (선택)
- 소셜 로그인 요청 예시 : uri 지정 없이 로그인 요청
<img width="1432" height="842" alt="image" src="https://github.com/user-attachments/assets/7be86a4d-da2e-4fa2-bb9a-1fe3987db4af" />

- 기본값 주소로 이동 (localhost:3000/auth/callback)
<img width="1430" height="817" alt="image" src="https://github.com/user-attachments/assets/4daa72ef-6633-424a-acc9-68873f905eb6" />

- 소셜 로그인 요청 예시 : uri 지정 로그인 요청
<img width="1416" height="909" alt="image" src="https://github.com/user-attachments/assets/7a166308-4672-4853-bea0-1a7114db3ae4" />
- 클라이언트가 지정한 주소로 이동
<img width="1434" height="872" alt="image" src="https://github.com/user-attachments/assets/00ca214d-ae51-4997-9e9d-65a319a6ab38" />



## 🧩 기타 참고사항
- 현재 uri을 쿼리로 지정하지 않을 경우, localhost:3000/auth/callback으로 리다이렉트 되도록 설정했습니다.
- 추후 배포 도메인에 따라 변경될 예정입니다.
