### PR TITLE
♻️ refactor: SecurityContext로부터 가져오는 사용자 정보 호출 관심사 분리

### DIFF
--- a/src/main/java/com/grepp/spring/infra/auth/CurrentUser.java
+++ b/src/main/java/com/grepp/spring/infra/auth/CurrentUser.java
@@ -1,0 +1,13 @@
+package com.grepp.spring.infra.auth;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+// CurrentUserArgumentResolver 를 위한 마킹 어노테이션
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CurrentUser {
+
+}

--- a/src/main/java/com/grepp/spring/infra/auth/CurrentUserArgumentResolver.java
+++ b/src/main/java/com/grepp/spring/infra/auth/CurrentUserArgumentResolver.java
@@ -1,0 +1,34 @@
+package com.grepp.spring.infra.auth;
+
+
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        // CurrentUser 어노테이션이 붙어있고 String 타입인지 체크
+        return parameter.hasParameterAnnotation(CurrentUser.class) && parameter.getParameterType().equals(String.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+        NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            // 인증되지 않은 사용자라면 예외 처리
+            return null;
+        }
+        // 사용자 ID 반환
+        return authentication.getName();
+    }
+}

--- a/src/main/java/com/grepp/spring/infra/config/WebConfig.java
+++ b/src/main/java/com/grepp/spring/infra/config/WebConfig.java
@@ -1,13 +1,25 @@
 package com.grepp.spring.infra.config;
 
+import com.grepp.spring.infra.auth.CurrentUserArgumentResolver;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
+
+    private final CurrentUserArgumentResolver currentUserArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(currentUserArgumentResolver);
+    }
 
     // 2025.7.11 기준 Front Server 테스트 주소인 https://localhost:3000 이 들어가야 합니다.
     // 빌드 시 application.yml 를 확인해주세요.


### PR DESCRIPTION
## ✅ 관련 이슈
- close #169 

## 🛠️ 작업 내용
- Spring MVC의 메서드의 파라미터를 처리를 담당하는 HandlerMethodArgumentResolver 의 구현체 생성
- 마킹 어노테이션 생성
- 커스텀 Resolver가 Spring MVC의 파라미터 처리 파이프라인에 포함되도록 WebConfig에 추가

## 📸 스크린샷
- 우리가 테스트 코드를 작성하면서 관심을 갖는 관심사 분리에 맞게 개선을 해보았습니다.
- 지금은 컨트롤러 혹은 서비스 메서드에서 인증 정보를 호출하기에, 로직을 분리할 필요가 있었습니다.
- 아래 코드는 기존에 제가 작성한 컨트롤러 메서드입니다. 내부적으로 인증 정보를 추출하고 있습니다.
<img width="804" height="216" alt="image" src="https://github.com/user-attachments/assets/8dd6de30-dc5f-446f-8a11-ac23a0fdb460" />

- 다음은 리팩토링된 코드입니다.
<img width="991" height="153" alt="image" src="https://github.com/user-attachments/assets/bf79e4f3-3476-4237-89f2-fd69455565b0" />

- 더 이상 비즈니스 로직과 관계없는 인증 정보 추출을 포함하지 않으며,
커스텀 어노테이션으로 마킹된 파라미터를 Spring MVC가 CurrentUserArgumentResolver 로 처리합니다.

- 앞으로 특정 메서드에서 현재 사용자의 정보가 필요한 경우,
메서드 파라미터에 `@CurrentUser String userId` 를 넣으면 내부적으로 userId 사용이 가능합니다.

## 🧩 기타 참고사항
- 기존 로직에서
```
Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
String userId = authentication.getName();
```
을 삭제하고, 메서드 파라미터에 `@CurrentUser String userId` 를 넣는 것으로 리팩토링이 가능하니 참고바랍니다.
