### PR TITLE
♻️ refactor: 인증 및 회원 기능 리팩터링 (+ Swagger 관련 수정)

### DIFF
--- a/src/main/java/com/grepp/spring/app/controller/api/auth/AuthController.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/auth/AuthController.java
@@ -2,28 +2,21 @@ package com.grepp.spring.app.controller.api.auth;
 
 import com.grepp.spring.app.controller.api.auth.payload.request.LoginRequest;
 import com.grepp.spring.app.controller.api.auth.payload.response.TokenResponse;
+import com.grepp.spring.app.model.auth.dto.NewTokensDto;
 import com.grepp.spring.app.model.auth.dto.TokenDto;
-import com.grepp.spring.app.model.auth.token.RefreshTokenService;
-import com.grepp.spring.app.model.auth.token.entity.RefreshToken;
 import com.grepp.spring.app.model.auth.AuthService;
 import com.grepp.spring.app.model.auth.code.AuthToken;
-import com.grepp.spring.app.model.member.code.Role;
 import com.grepp.spring.infra.auth.jwt.JwtTokenProvider;
 import com.grepp.spring.infra.auth.jwt.TokenCookieFactory;
-import com.grepp.spring.infra.auth.jwt.dto.AccessTokenDto;
-import com.grepp.spring.infra.auth.jwt.dto.RefreshTokenDto;
-import com.grepp.spring.infra.error.exceptions.AuthApiException;
 import com.grepp.spring.infra.error.exceptions.member.InvalidTokenException;
 import com.grepp.spring.infra.response.ApiResponse;
 import com.grepp.spring.infra.response.ResponseCode;
-import io.jsonwebtoken.Claims;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -41,7 +34,6 @@ public class AuthController {
 
     private final AuthService authService;
     private final JwtTokenProvider jwtTokenProvider;
-    private final RefreshTokenService refreshTokenService;
 
     // 백엔드의 편안한 테스트를 위해 로그인을 살려보겠습니다.
     // 나중에 삭제할 임시 로그인 메서드.
@@ -82,25 +74,8 @@ public class AuthController {
     @PostMapping("/logout")
     public ResponseEntity<ApiResponse<Void>> logout(HttpServletRequest request, HttpServletResponse response) {
 
-        // 쿠키에서 토큰 제거
-        ResponseCookie deleteAccessTokenCookie = TokenCookieFactory.createExpiredToken(AuthToken.ACCESS_TOKEN.name());
-        response.addHeader(HttpHeaders.SET_COOKIE, deleteAccessTokenCookie.toString());
-
-        ResponseCookie deleteRefreshTokenCookie = TokenCookieFactory.createExpiredToken(AuthToken.REFRESH_TOKEN.name());
-        response.addHeader(HttpHeaders.SET_COOKIE, deleteRefreshTokenCookie.toString());
-
-        ResponseCookie deleteSessionIdCookie = TokenCookieFactory.createExpiredToken(AuthToken.AUTH_SERVER_SESSION_ID.name());
-        response.addHeader(HttpHeaders.SET_COOKIE, deleteSessionIdCookie.toString());
-
-        // Redis에서 리프레시 토큰 제거
-        String accessToken = jwtTokenProvider.resolveToken(request, AuthToken.ACCESS_TOKEN);
-        if (accessToken != null && jwtTokenProvider.validateToken(accessToken)) {
-            String atJti = jwtTokenProvider.getClaims(accessToken).getId();
-            refreshTokenService.deleteByAccessTokenId(atJti);
-        }
-
+        authService.logout(request, response);
         SecurityContextHolder.clearContext();
-
         return ResponseEntity.ok(ApiResponse.noContent());
     }
 
@@ -112,61 +87,17 @@ public class AuthController {
         String accessToken = jwtTokenProvider.resolveToken(request, AuthToken.ACCESS_TOKEN);
         String refreshToken = jwtTokenProvider.resolveToken(request, AuthToken.REFRESH_TOKEN);
 
-        // 리프레시 토큰의 유효성 검증
-        if (refreshToken == null || !jwtTokenProvider.validateToken(refreshToken)){
-            throw new InvalidTokenException(ResponseCode.INVALID_TOKEN, "엑세스 토큰과 리프레시 토큰의 정보가 일치하지 않습니다.");
-        }
-
-        // 토큰에서 Claim 을 추출합시다.
-        Claims accessClaims = jwtTokenProvider.getClaims(accessToken);
-        String atJtiFromAccess = accessClaims.getId(); // 기존 Access Token의 JTI
-        String userId = accessClaims.getSubject();
-
-        Claims refreshClaims = jwtTokenProvider.getClaims(refreshToken);
-        String atJtiFromRefresh = refreshClaims.get("atId", String.class);
-        String refreshJti = refreshClaims.getId(); // Refresh Token의 JTI
-
-        // 엑세스 토큰과 리프레시 토큰의 JTI 일치 여부 확인
-        if (!atJtiFromAccess.equals(atJtiFromRefresh)) {
-            // 일치하지 않으면 즉시 Redis에서 제거
-            refreshTokenService.deleteByAccessTokenId(atJtiFromRefresh);
-            throw new InvalidTokenException(ResponseCode.INVALID_TOKEN, "엑세스 토큰과 리프레시 토큰의 정보가 일치하지 않습니다.");
-        }
-
-        // Redis에 저장된 리프레시 토큰 조회 및 검증
-        RefreshToken currentRefreshToken = refreshTokenService.findByAccessTokenId(atJtiFromRefresh);
-        if (currentRefreshToken == null || !currentRefreshToken.getId().equals(refreshJti)) {
-            refreshTokenService.deleteByAccessTokenId(atJtiFromRefresh);
-            throw new InvalidTokenException(ResponseCode.INVALID_TOKEN, "엑세스 토큰과 리프레시 토큰의 정보가 일치하지 않습니다.");
-        }
-
-        // 새로운 Access Token 생성
-        AccessTokenDto newAccessTokenDto = jwtTokenProvider.generateAccessToken(userId, Role.ROLE_USER.name());
-        // 새로운 Refresh token 생성
-        RefreshTokenDto newRefreshTokenDto = jwtTokenProvider.generateRefreshToken(
-            newAccessTokenDto.getJti());
-        // 기존에 Redis에 저장된 Refresh Token 삭제 및 새로운 토큰 저장
-        refreshTokenService.deleteByAccessTokenId(atJtiFromRefresh);
-
-        // 새 Refresh Token을 Redis 에 저장합니다.
-        RefreshToken newRefreshToken = RefreshToken.builder()
-            .id(newRefreshTokenDto.getJti())
-            .atId(newAccessTokenDto.getJti())
-            .ttl(jwtTokenProvider.getRefreshTokenExpiration())
-            .build();
-        refreshTokenService.saveWithAtId(newRefreshToken);
+        // Service 에게 비즈니스 로직 모두 위임
+        NewTokensDto newTokens = authService.updateTokens(accessToken, refreshToken);
 
         // 쿠키에 토큰 저장
         ResponseCookie newAccessTokenCookie = TokenCookieFactory.create(AuthToken.ACCESS_TOKEN.name(),
-            newAccessTokenDto.getToken(), newAccessTokenDto.getExpires());
+            newTokens.getNewAccessToken().getToken(), newTokens.getNewAccessToken().getExpires());
         ResponseCookie newRefreshTokenCookie = TokenCookieFactory.create(AuthToken.REFRESH_TOKEN.name(),
-            newRefreshTokenDto.getToken(), newRefreshTokenDto.getExpires());
+            newTokens.getNewRefreshToken().getToken(), newTokens.getNewRefreshToken().getExpires());
 
         response.addHeader("Set-Cookie", newAccessTokenCookie.toString());
         response.addHeader("Set-Cookie", newRefreshTokenCookie.toString());
-
-        log.info("갱신된 Access Token: {}", newAccessTokenDto.getToken());
-        log.info("갱신된 Refresh Token: {}", newRefreshTokenDto.getToken());
 
         return ResponseEntity.ok(ApiResponse.success("토큰이 갱신되었습니다."));
     }

--- a/src/main/java/com/grepp/spring/app/controller/api/member/MemberController.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/member/MemberController.java
@@ -2,20 +2,14 @@ package com.grepp.spring.app.controller.api.member;
 
 import com.grepp.spring.app.controller.api.member.payload.MemberInfoResponse;
 import com.grepp.spring.app.controller.api.member.payload.ModifyMemberInfoResponse;
-import com.grepp.spring.app.model.member.entity.Member;
 import com.grepp.spring.app.model.member.service.MemberService;
+import com.grepp.spring.infra.auth.CurrentUser;
 import com.grepp.spring.infra.response.ApiResponse;
-import com.grepp.spring.infra.response.ResponseCode;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -31,63 +25,32 @@ public class MemberController {
 
     @Operation(summary = "사용자 정보 조회", description = "현재 로그인 중인 사용자의 정보를 가져올 수 있습니다.")
     @GetMapping("/me")
-    public ResponseEntity<ApiResponse<MemberInfoResponse>> getMemberInfo(Authentication authentication) {
-
-        try {
-            UserDetails userDetails = (UserDetails) authentication.getPrincipal();
-            String username = userDetails.getUsername();
-
-            Member member = memberService.findById(username).orElseThrow();
-
-            MemberInfoResponse response = new MemberInfoResponse();
-            response.setId(member.getId());
-            response.setName(member.getName());
-            response.setEmail(member.getEmail());
-            response.setRole(member.getRole().name());
-            response.setProfileImageNumber(member.getProfileImageNumber());
-            response.setProvider(member.getProvider().name());
-
-            return ResponseEntity.ok(ApiResponse.success(response));
-            // 데이터베이스에 등록되지 않은 사용자인 경우
-        } catch (NoSuchElementException e) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(ApiResponse.error(ResponseCode.NOT_FOUND,"유저를 찾을 수 없습니다."));
-            // 그 외 예상치 못한 예외 처리
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ApiResponse.error(ResponseCode.INTERNAL_SERVER_ERROR, ResponseCode.INTERNAL_SERVER_ERROR.message()));
-        }
-        // 위 예외들은 추후 GlobalAdvice로 처리하는 방법을 생각중입니다.
+    public ResponseEntity<ApiResponse<MemberInfoResponse>> getMemberInfo(@CurrentUser String userId) {
+        // Service 로 모든 비즈니스 로직 위임
+        MemberInfoResponse response = memberService.getMemberInfoResponse(userId);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     @Operation(summary = "회원 탈퇴", description = "서비스 탈퇴를 진행합니다.")
     @DeleteMapping("/withdraw")
-    public ResponseEntity<ApiResponse<Void>> withdraw(HttpServletResponse response, HttpServletRequest request) {
+    public ResponseEntity<ApiResponse<Void>> withdraw(HttpServletResponse response, HttpServletRequest request,
+        @CurrentUser String userId) {
 
-        // SecurityContextHolder 에서 사용자 정보 가져오기
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        String userId = authentication.getName();
         memberService.withdraw(userId, response, request);
         return ResponseEntity.ok(ApiResponse.noContent());
     }
 
     @Operation(summary = "회원 이름 수정", description = "사용자의 이름을 수정합니다.")
     @PatchMapping("/me")
-    public ResponseEntity<ApiResponse<ModifyMemberInfoResponse>> modifyMemberInfo(String username){
+    public ResponseEntity<ApiResponse<ModifyMemberInfoResponse>> modifyMemberInfo(@CurrentUser String userId, String username){
 
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        String userId = authentication.getName();
-
-        ModifyMemberInfoResponse response = memberService.modifyMemberInfo(userId, username);
+        ModifyMemberInfoResponse response = memberService.modifyMemberName(userId, username);
         return ResponseEntity.ok(ApiResponse.success("이름이 정상적으로 변경되었습니다.", response));
     }
 
     @Operation(summary = "회원 프로필 변경", description = "사용자의 프로필 캐릭터를 랜덤으로 변경합니다.")
     @PatchMapping("/profile")
-    public ResponseEntity<ApiResponse<ModifyMemberInfoResponse>> modifyProfileImage(){
-
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        String userId = authentication.getName();
+    public ResponseEntity<ApiResponse<ModifyMemberInfoResponse>> modifyProfileImage(@CurrentUser String userId){
 
         ModifyMemberInfoResponse response = memberService.modifyProfileImage(userId);
         return ResponseEntity.ok(ApiResponse.success("프로필이 임의의 캐릭터로 변경되었습니다.", response));

--- a/src/main/java/com/grepp/spring/app/controller/api/member/payload/MemberInfoResponse.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/member/payload/MemberInfoResponse.java
@@ -1,10 +1,13 @@
 package com.grepp.spring.app.controller.api.member.payload;
 
+import com.grepp.spring.app.model.member.entity.Member;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Setter
 @Getter
+@NoArgsConstructor
 public class MemberInfoResponse {
 
     private String id;
@@ -13,5 +16,17 @@ public class MemberInfoResponse {
     private Integer profileImageNumber;
     private String provider;
     private String role;
+
+    // MemberInfoResponse 생성하는 정적 팩토리 메서드
+    public static MemberInfoResponse from(Member member) {
+        MemberInfoResponse response = new MemberInfoResponse();
+        response.setId(member.getId());
+        response.setEmail(member.getEmail());
+        response.setName(member.getName());
+        response.setProfileImageNumber(member.getProfileImageNumber());
+        response.setProvider(member.getProvider().name());
+        response.setRole(member.getRole().name());
+        return response;
+    }
 
 }

--- a/src/main/java/com/grepp/spring/app/model/auth/dto/NewTokensDto.java
+++ b/src/main/java/com/grepp/spring/app/model/auth/dto/NewTokensDto.java
@@ -1,0 +1,14 @@
+package com.grepp.spring.app.model.auth.dto;
+
+import com.grepp.spring.infra.auth.jwt.dto.AccessTokenDto;
+import com.grepp.spring.infra.auth.jwt.dto.RefreshTokenDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class NewTokensDto {
+    private AccessTokenDto newAccessToken;
+    private RefreshTokenDto newRefreshToken;
+
+}

--- a/src/main/java/com/grepp/spring/app/model/member/entity/Member.java
+++ b/src/main/java/com/grepp/spring/app/model/member/entity/Member.java
@@ -9,6 +9,7 @@ import com.grepp.spring.app.model.mypage.entity.FavoriteLocation;
 import com.grepp.spring.app.model.mypage.entity.FavoriteTimetable;
 import com.grepp.spring.app.model.schedule.entity.ScheduleMember;
 import com.grepp.spring.infra.entity.BaseEntity;
+import com.grepp.spring.infra.error.exceptions.member.InvalidNameException;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -24,8 +25,10 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Pattern;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.util.StringUtils;
 
 
 @Entity
@@ -95,7 +98,38 @@ public class Member extends BaseEntity {
     private List<ScheduleMember> scheduleMembers = new ArrayList<>();
 
 
+    // 객체지향적 설계로 변경하는 과정입니다...
+    // 이름을 수정하는 메서드
+    public void updateName(String newName) {
+        if (StringUtils.hasText(newName)) {
+            newName = newName.trim();
+            validateName(newName);
+            this.name = newName;
+        }
+    }
 
+    // 이름 유효성 검증은 Member 엔티티 내부 메서드로 이동
+    private void validateName(String username){
+        if (username == null) {
+            throw new InvalidNameException("이름은 필수 입력값입니다.");
+        }
+        if (username.length() < 2 || username.length() > 10) {
+            throw new InvalidNameException("이름은 2자 이상 10자 이하로만 가능합니다.");
+        }
+        String pattern = "^[가-힣a-zA-Z](?:[가-힣a-zA-Z ]*[가-힣a-zA-Z])?$";
+        if (!username.matches(pattern)) {
+            throw new InvalidNameException("이름은 한글, 영문만 사용 가능하며, 숫자나 특수문자는 포함할 수 없습니다.");
+        }
+    }
 
-
+    // 프로필 이미지를 수정하는 메서드
+    public void updateProfileImage() {
+        int currentProfileNumber = this.profileImageNumber;
+        int newProfileNumber;
+        Random random = new Random();
+        do {
+            newProfileNumber = random.nextInt(8);
+        } while (newProfileNumber == currentProfileNumber);
+        this.profileImageNumber = newProfileNumber;
+    }
 }

--- a/src/main/java/com/grepp/spring/infra/RandomPicker.java
+++ b/src/main/java/com/grepp/spring/infra/RandomPicker.java
@@ -1,0 +1,17 @@
+package com.grepp.spring.infra;
+
+import java.util.List;
+import java.util.Random;
+
+public class RandomPicker {
+
+    private static final Random RANDOM = new Random();
+
+    public static <T> T pickRandom(List<T> members) {
+        if (members == null || members.isEmpty()) {
+            throw new IllegalArgumentException("리스트가 비어 있어서 랜덤 추출이 불가능합니다.");
+        }
+        int randomIndex = RANDOM.nextInt(members.size());
+        return members.get(randomIndex);
+    }
+}

--- a/src/main/java/com/grepp/spring/infra/config/SwaggerConfig.java
+++ b/src/main/java/com/grepp/spring/infra/config/SwaggerConfig.java
@@ -1,21 +1,45 @@
 package com.grepp.spring.infra.config;
 
+import com.grepp.spring.infra.auth.CurrentUser;
+import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.media.Content;
 import io.swagger.v3.oas.models.media.MediaType;
 import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.parameters.HeaderParameter;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springdoc.core.customizers.OperationCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.HandlerMethod;
 
 
 @Configuration
 public class SwaggerConfig {
+
+    @Bean
+    public OperationCustomizer customizeOperation() {
+        return (Operation operation, HandlerMethod handlerMethod) -> {
+            // 해당 핸들러 메서드의 파라미터들을 순회
+            for (java.lang.reflect.Parameter methodParameter : handlerMethod.getMethod().getParameters()) {
+                // @CurrentUser 어노테이션이 붙어있는지 확인
+                if (methodParameter.isAnnotationPresent(CurrentUser.class)) {
+                    // 해당 파라미터를 Swagger 명세에서 제거
+                    // operation.getParameters()는 null일 수 있으므로 null 체크
+                    if (operation.getParameters() != null) {
+                        operation.getParameters().removeIf(p -> p.getName().equals(methodParameter.getName()));
+                    }
+                    // 보안 요구사항 추가 (OpenAPI 3.0의 SecurityScheme 설정이 선행되어야 함)
+                    operation.addSecurityItem(new SecurityRequirement().addList("bearerAuth")); // "bearerAuth"는 SecurityScheme에 정의된 이름
+                }
+            }
+            return operation;
+        };
+    }
 
     @Bean
     public OpenAPI openApiSpec() {


### PR DESCRIPTION
## ✅ 관련 이슈
- close #174 

## 🛠️ 작업 내용
- 회원 기능(회원 정보 조회, 이름 변경, 프로필 사진 변경) Controller에 있는 비즈니스 로직을 Service로 위임
- 인증 기능(로그아웃, 토큰 갱신) Controller에 있는 비즈니스 로직을 Service로 위임
- 인증 정보 추출 로직 분리(CurrnentUser)
- 권한 위임 시 사용할 랜덤 추출 유틸리티 메서드 작성
- Swagger에서 CurrentUser 어노테이션 파라미터를 인식하지 못하는 문제 해결

## 🧩 기타 참고사항
- 회원 탈퇴 관련 메서드는 이어서 리팩터링할 예정입니다.
