### PR TITLE
✨ feat: 참여자 전원 시간대 조회 항목 추가 및 이벤트 조율 결과 생성 검증 강화

### DIFF
--- a/src/main/java/com/grepp/spring/app/controller/api/event/payload/response/AllTimeScheduleResponse.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/event/payload/response/AllTimeScheduleResponse.java
@@ -14,6 +14,7 @@ public class AllTimeScheduleResponse {
     private final String description;
     private final TimeTable timeTable;
     private final List<MemberSchedule> memberSchedules;
+    private final Integer maxMembers;
     private final Integer totalMembers;
     private final Integer confirmedMembers;
     private final Map<String, List<Integer>> participantCounts;

--- a/src/main/java/com/grepp/spring/app/model/event/dto/AllTimeScheduleDto.java
+++ b/src/main/java/com/grepp/spring/app/model/event/dto/AllTimeScheduleDto.java
@@ -18,6 +18,7 @@ public class AllTimeScheduleDto {
     private final String description;
     private final TimeTableDto timeTable;
     private final List<MemberScheduleDto> memberSchedules;
+    private final Integer maxMembers;
     private final Integer totalMembers;
     private final Integer confirmedMembers;
     private final Map<String, List<Integer>> participantCounts;
@@ -80,6 +81,7 @@ public class AllTimeScheduleDto {
             .description(dto.getDescription())
             .timeTable(timeTable)
             .memberSchedules(memberSchedules)
+            .maxMembers(dto.getMaxMembers())
             .totalMembers(dto.getTotalMembers())
             .confirmedMembers(dto.getConfirmedMembers())
             .participantCounts(dto.getParticipantCounts())

--- a/src/main/java/com/grepp/spring/app/model/event/service/EventQueryService.java
+++ b/src/main/java/com/grepp/spring/app/model/event/service/EventQueryService.java
@@ -94,6 +94,7 @@ public class EventQueryService {
             .eventTitle(event.getTitle())
             .description(event.getDescription())
             .timeTable(timeTable)
+            .maxMembers(event.getMaxMember())
             .memberSchedules(memberSchedules)
             .totalMembers(eventMembers.size())
             .confirmedMembers(confirmedMembers)

--- a/src/main/java/com/grepp/spring/app/model/event/service/EventScheduleResultService.java
+++ b/src/main/java/com/grepp/spring/app/model/event/service/EventScheduleResultService.java
@@ -51,6 +51,10 @@ public class EventScheduleResultService {
         List<CandidateDate> candidateDates = getCandidateDates(eventId);
         Map<Long, List<TempSchedule>> memberScheduleMap = getMemberScheduleMap(eventMembers);
 
+        if (memberScheduleMap.isEmpty()) {
+            throw new InvalidEventDataException(EventErrorCode.CANNOT_CREATE_SCHEDULE_RESULT);
+        }
+
         List<RecommendationDto.TimeSlot> availableTimeSlots = analyzeAvailableTimeSlots(candidateDates, eventMembers, memberScheduleMap);
 
         List<RecommendationDto.ContinuousTimeRange> continuousRanges = mergeContinuousTimeSlots(availableTimeSlots);

--- a/src/main/java/com/grepp/spring/infra/response/EventErrorCode.java
+++ b/src/main/java/com/grepp/spring/infra/response/EventErrorCode.java
@@ -7,6 +7,7 @@ public enum EventErrorCode {
     ALREADY_COMPLETED_SCHEDULE("400", HttpStatus.BAD_REQUEST, "이미 확정된 일정입니다."),
     CANNOT_COMPLETE_EMPTY_SCHEDULE("400", HttpStatus.BAD_REQUEST, "빈 일정은 확정할 수 없습니다."),
     EVENT_MEMBER_LIMIT_EXCEEDED("400", HttpStatus.BAD_REQUEST, "이벤트 참여 인원이 초과되었습니다."),
+    CANNOT_CREATE_SCHEDULE_RESULT("400", HttpStatus.BAD_REQUEST, "일정 조율 결과를 생성할 수 없습니다."),
     AUTHENTICATION_REQUIRED("401", HttpStatus.UNAUTHORIZED, "로그인이 필요합니다."),
     NOT_EVENT_MEMBER("403", HttpStatus.FORBIDDEN, "해당 이벤트의 참여자가 아닙니다."),
     NOT_GROUP_MEMBER("403", HttpStatus.FORBIDDEN, "해당 그룹의 멤버가 아닙니다."),


### PR DESCRIPTION
## 🛠️ 작업 내용
- 프론트 요청에 따라 참여자 전원 시간대 조회 값으로 이벤트 최대 인원을 추가
- 이벤트 조율 결과 생성 시 예외처리 추가(참여자 입력 시간대가 없는 경우)

## 📸 스크린샷
- 참여자 전원 시간대 조회 응답
<img width="854" height="247" alt="스크린샷 2025-07-25 오전 12 43 30" src="https://github.com/user-attachments/assets/4ee70081-364c-4163-b9ed-b86910b01d71" />

- 참여자가 입력한 시간대가 없는 경우: 이벤트 조율 결과 생성 요청 에러
<img width="940" height="195" alt="스크린샷 2025-07-25 오전 1 01 56" src="https://github.com/user-attachments/assets/caa23710-c84b-488f-a616-a63566015705" />
