### PR TITLE
✨ feat: 캘린더 ID 등록 조회 및 검증 + 예외 처리

### DIFF
--- a/src/main/java/com/grepp/spring/app/controller/api/mainpage/MainPageController.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/mainpage/MainPageController.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
@@ -32,6 +33,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/main-page")
 public class MainPageController {
 
+  @Autowired
   private final MainPageService mainPageService;
 
 

--- a/src/main/java/com/grepp/spring/app/controller/api/mypage/MypageController.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/mypage/MypageController.java
@@ -9,6 +9,7 @@ import com.grepp.spring.app.controller.api.mypage.payload.response.CreateFavorit
 import com.grepp.spring.app.controller.api.mypage.payload.response.CreateFavoriteTimeResponse;
 import com.grepp.spring.app.controller.api.mypage.payload.response.ModifyFavoritePlaceResponse;
 import com.grepp.spring.app.controller.api.mypage.payload.response.PublicCalendarIdResponse;
+import com.grepp.spring.app.model.mainpage.service.PublicCalendarService;
 import com.grepp.spring.app.model.mypage.dto.FavoriteLocationDto;
 import com.grepp.spring.app.model.mypage.service.MypageService;
 import com.grepp.spring.app.model.mypage.service.PublicCalendarIdService;
@@ -39,6 +40,7 @@ public class MypageController {
 
   private final MypageService mypageService;
   private final PublicCalendarIdService publicCalendarIdService;
+  private final PublicCalendarService publicCalendarService;
 
 
   // 즐겨찾기 장소 등록
@@ -120,6 +122,22 @@ public class MypageController {
 
   }
 
+  @Operation(summary = "공개 캘린더 ID 조회")
+  @GetMapping("/calendar/public-id")
+  public ResponseEntity<ApiResponse<PublicCalendarIdResponse>> getPublicCalendarId() {
+
+    String memberId = extractCurrentMemberId();
+
+    // DB 에서 ID 조회하기
+    String publicCalendarId = publicCalendarIdService.getPublicCalendarId(memberId);
+
+    PublicCalendarIdResponse response = new PublicCalendarIdResponse(publicCalendarId);
+
+
+    return ResponseEntity.ok(ApiResponse.success(response));
+
+  }
+
 
   @Operation(summary = "공개 캘린더 ID 입력받기")
   @PostMapping("/calendar/public-id")
@@ -129,6 +147,9 @@ public class MypageController {
     String publicCalendarId = request.getPublicCalendarId();
 
     String memberId = extractCurrentMemberId();
+
+    // 유효한 캘린더 id 인지 검증 위해 api 호출
+    publicCalendarService.fetchPublicCalendarEvents(publicCalendarId);
 
     // DB 에 저장하기
     publicCalendarIdService.savePublicCalendarId(memberId, publicCalendarId);

--- a/src/main/java/com/grepp/spring/app/model/mainpage/service/PublicCalendarService.java
+++ b/src/main/java/com/grepp/spring/app/model/mainpage/service/PublicCalendarService.java
@@ -3,17 +3,21 @@ package com.grepp.spring.app.model.mainpage.service;
 import com.grepp.spring.app.model.member.repository.MemberRepository;
 import com.grepp.spring.app.model.mypage.dto.PublicCalendarEventDto;
 import com.grepp.spring.app.model.mypage.service.PublicCalendarIdService;
-import com.grepp.spring.infra.error.exceptions.mypage.MemberNotFoundException;
+import com.grepp.spring.infra.error.exceptions.mypage.GoogleCalendarApiFailedException;
+import com.grepp.spring.infra.error.exceptions.mypage.InvalidPublicCalendarIdException;
 import com.grepp.spring.infra.response.MyPageErrorCode;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
 @Service
@@ -36,53 +40,70 @@ public class PublicCalendarService {
     String url = "https://www.googleapis.com/calendar/v3/calendars/"
         + publicCalendarId + "/events?key=" + googleApiKey;
 
-    // google api 호출하기
-    ResponseEntity<Map> response = restTemplate.exchange(
-        url,
-        HttpMethod.GET,
-        null, // 요청 본문 없음
-        Map.class
-    );
+    try {
+      // google api 호출하기
+      ResponseEntity<Map> response = restTemplate.exchange(
+          url,
+          HttpMethod.GET,
+          null, // 요청 본문 없음
+          Map.class
+      );
 
-    // 응답 JSON 파싱
-    Map<String, Object> body = response.getBody();
-    // items 배열 꺼내기
-    List<Map<String, Object>> items = (List<Map<String, Object>>) body.get("items");
+      // 응답 JSON 파싱
+      Map<String, Object> body = response.getBody();
+      if (body == null || !body.containsKey("items")) { // null 일 때 빈 리스트 반환
+        return Collections.emptyList();
+      }
 
-    List<PublicCalendarEventDto> result = new ArrayList<>();
+      // items 배열 꺼내기
+      List<Map<String, Object>> items = (List<Map<String, Object>>) body.get("items");
 
-    // 이벤트 데이터 처리 (구글 일정)
-    for (Map<String, Object> item : items) {
+      List<PublicCalendarEventDto> result = new ArrayList<>();
 
-      String eventId = (String) item.get("id");
-      String title = (String) item.get("summary");
-      String status = (String) item.get("status");
-//    String htmlLink = (String) item.get("htmlLink");
-      // status: confirmed, tentative, cancelled
+      // 이벤트 데이터 처리 (구글 일정)
+      for (Map<String, Object> item : items) {
 
-      // 시작/종료는 dateTime 또는 date 중 하나가 옴
-      // date: 종일 이벤트 (0723-0724), dateTime: 일반 + 걸쳐있는 이벤트에 timezone 까지...
-      Map<String, String> startMap = (Map<String, String>) item.get("start");
-      Map<String, String> endMap = (Map<String, String>) item.get("end");
+        String eventId = (String) item.get("id");
+        String title = (String) item.get("summary");
+        String status = (String) item.get("status");
+        //    String htmlLink = (String) item.get("htmlLink");
+        // status: confirmed, tentative, cancelled
 
-      // getOrDefault: dateTime 있으면 그걸 쓰고 (일반 일정), 없으면 디폴트인 date (종일 일정)
-      String start = startMap.getOrDefault("dateTime", startMap.get("date"));
-      String end = endMap.getOrDefault("dateTime", endMap.get("date"));
-      // startMap 에 date 키가 있으면 종일 일정 -> true
-      boolean isAllDay = startMap.containsKey("date");
+        // 시작/종료는 dateTime 또는 date 중 하나가 옴
+        // date: 종일 이벤트 (0723-0724), dateTime: 일반 + 걸쳐있는 이벤트에 timezone 까지...
+        Map<String, String> startMap = (Map<String, String>) item.get("start");
+        Map<String, String> endMap = (Map<String, String>) item.get("end");
 
-      PublicCalendarEventDto dto = PublicCalendarEventDto.builder()
-          .eventId(eventId)
-          .title(title)
-          .start(start)
-          .end(end)
-          .allDay(isAllDay)
-          .status(status)
-//        .htmlLink(htmlLink)
-          .build();
+        // getOrDefault: dateTime 있으면 그걸 쓰고 (일반 일정), 없으면 디폴트인 date (종일 일정)
+        String start = startMap.getOrDefault("dateTime", startMap.get("date"));
+        String end = endMap.getOrDefault("dateTime", endMap.get("date"));
+        // startMap 에 date 키가 있으면 종일 일정 -> true
+        boolean isAllDay = startMap.containsKey("date");
 
-      result.add(dto);
+        PublicCalendarEventDto dto = PublicCalendarEventDto.builder()
+            .eventId(eventId)
+            .title(title)
+            .start(start)
+            .end(end)
+            .allDay(isAllDay)
+            .status(status)
+            //        .htmlLink(htmlLink)
+            .build();
+
+        result.add(dto);
+      }
+      return result;
+
+    } catch (HttpClientErrorException e) {
+      if (e.getStatusCode() == HttpStatus.NOT_FOUND || e.getStatusCode() == HttpStatus.FORBIDDEN) {
+        // 잘못된/권한 없는 캘린더 -> 사용자 잘못..
+        throw new InvalidPublicCalendarIdException(MyPageErrorCode.INVALID_PUBLIC_CALENDAR_ID);
+      }
+      // 그 외 400 번대 -> 외부 API 문제로 간주
+      throw new GoogleCalendarApiFailedException(MyPageErrorCode.GOOGLE_CALENDAR_API_FAILED);
+    } catch (RestClientException e) {
+      // 그외 네트워크, 500 번대 등 -> 외부 API 문제
+      throw new GoogleCalendarApiFailedException(MyPageErrorCode.GOOGLE_CALENDAR_API_FAILED);
     }
-    return result;
   }
 }

--- a/src/main/java/com/grepp/spring/app/model/mypage/service/PublicCalendarIdService.java
+++ b/src/main/java/com/grepp/spring/app/model/mypage/service/PublicCalendarIdService.java
@@ -5,7 +5,9 @@ import com.grepp.spring.app.model.mainpage.entity.Calendar;
 import com.grepp.spring.app.model.member.entity.Member;
 import com.grepp.spring.app.model.member.repository.MemberRepository;
 import com.grepp.spring.app.model.mypage.repository.CalendarRepository;
+import com.grepp.spring.infra.error.exceptions.mypage.InvalidPublicCalendarIdException;
 import com.grepp.spring.infra.error.exceptions.mypage.MemberNotFoundException;
+import com.grepp.spring.infra.error.exceptions.mypage.PublicCalendarIdNotFoundException;
 import com.grepp.spring.infra.response.MyPageErrorCode;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +24,12 @@ public class PublicCalendarIdService {
   // 공개 캘린더 ID 저장
   @Transactional
   public void savePublicCalendarId(String memberId, String publicCalendarId) {
+
+    // null / 빈 문자열 저장 차단
+    if (publicCalendarId == null || publicCalendarId.trim().isEmpty()) {
+      throw new InvalidPublicCalendarIdException(MyPageErrorCode.INVALID_PUBLIC_CALENDAR_ID);
+    }
+
     Member member = memberRepository.findById(memberId)
         .orElseThrow(() -> new MemberNotFoundException(MyPageErrorCode.MEMBER_NOT_FOUND));
 
@@ -32,14 +40,15 @@ public class PublicCalendarIdService {
     calendarRepository.save(calendar);
   }
 
-  // 공개 캘린더 ID 로직에서 조회
+  // DB 에 저장된 공개 캘린더 ID 조회
   @Transactional(readOnly = true)
-  public Optional<String> getPublicCalendarId(String memberId) {
+  public String getPublicCalendarId(String memberId) {
     Member member = memberRepository.findById(memberId)
         .orElseThrow(() -> new MemberNotFoundException(MyPageErrorCode.MEMBER_NOT_FOUND));
 
     return calendarRepository.findByMember(member)
-        .map(Calendar::getPublicCalendarId);
+        .map(Calendar::getPublicCalendarId)
+        .orElseThrow(() -> new PublicCalendarIdNotFoundException(MyPageErrorCode.PUBLIC_CALENDAR_ID_NOT_FOUND));
   }
 
 }

--- a/src/main/java/com/grepp/spring/infra/error/exceptions/mypage/GoogleCalendarApiFailedException.java
+++ b/src/main/java/com/grepp/spring/infra/error/exceptions/mypage/GoogleCalendarApiFailedException.java
@@ -1,0 +1,25 @@
+package com.grepp.spring.infra.error.exceptions.mypage;
+
+import com.grepp.spring.infra.response.MyPageErrorCode;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class GoogleCalendarApiFailedException extends RuntimeException {
+
+  private final MyPageErrorCode code;
+
+  public GoogleCalendarApiFailedException(MyPageErrorCode code) {
+    this.code = code;
+  }
+
+  public GoogleCalendarApiFailedException(MyPageErrorCode code, Exception e) {
+    this.code = code;
+    log.error(e.getMessage(),e);
+  }
+
+  public MyPageErrorCode getCode() {
+    return code;
+  }
+
+
+}

--- a/src/main/java/com/grepp/spring/infra/error/exceptions/mypage/InvalidPublicCalendarIdException.java
+++ b/src/main/java/com/grepp/spring/infra/error/exceptions/mypage/InvalidPublicCalendarIdException.java
@@ -1,0 +1,25 @@
+package com.grepp.spring.infra.error.exceptions.mypage;
+
+import com.grepp.spring.infra.response.MyPageErrorCode;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class InvalidPublicCalendarIdException extends RuntimeException {
+
+  private final MyPageErrorCode code;
+
+  public InvalidPublicCalendarIdException(MyPageErrorCode code) {
+    this.code = code;
+  }
+
+  public InvalidPublicCalendarIdException(MyPageErrorCode code, Exception e) {
+    this.code = code;
+    log.error(e.getMessage(),e);
+  }
+
+  public MyPageErrorCode getCode() {
+    return code;
+  }
+
+
+}

--- a/src/main/java/com/grepp/spring/infra/error/exceptions/mypage/PublicCalendarIdNotFoundException.java
+++ b/src/main/java/com/grepp/spring/infra/error/exceptions/mypage/PublicCalendarIdNotFoundException.java
@@ -1,0 +1,25 @@
+package com.grepp.spring.infra.error.exceptions.mypage;
+
+import com.grepp.spring.infra.response.MyPageErrorCode;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class PublicCalendarIdNotFoundException extends RuntimeException {
+
+  private final MyPageErrorCode code;
+
+  public PublicCalendarIdNotFoundException(MyPageErrorCode code) {
+    this.code = code;
+  }
+
+  public PublicCalendarIdNotFoundException(MyPageErrorCode code, Exception e) {
+    this.code = code;
+    log.error(e.getMessage(),e);
+  }
+
+  public MyPageErrorCode getCode() {
+    return code;
+  }
+
+
+}

--- a/src/main/java/com/grepp/spring/infra/error/mypageAdvice/MyPageExceptionAdvice.java
+++ b/src/main/java/com/grepp/spring/infra/error/mypageAdvice/MyPageExceptionAdvice.java
@@ -9,10 +9,13 @@ import com.grepp.spring.infra.error.exceptions.mypage.FavoriteAlreadyExistExcept
 import com.grepp.spring.infra.error.exceptions.mypage.FavoriteNotFoundException;
 import com.grepp.spring.infra.error.exceptions.mypage.FavoriteSaveFailedException;
 import com.grepp.spring.infra.error.exceptions.mypage.GoogleAuthFailedException;
+import com.grepp.spring.infra.error.exceptions.mypage.GoogleCalendarApiFailedException;
 import com.grepp.spring.infra.error.exceptions.mypage.InvalidCalendarResponseException;
 import com.grepp.spring.infra.error.exceptions.mypage.InvalidFavoriteRequestException;
 import com.grepp.spring.infra.error.exceptions.mypage.InvalidMemberRequestException;
+import com.grepp.spring.infra.error.exceptions.mypage.InvalidPublicCalendarIdException;
 import com.grepp.spring.infra.error.exceptions.mypage.MemberNotFoundException;
+import com.grepp.spring.infra.error.exceptions.mypage.PublicCalendarIdNotFoundException;
 import com.grepp.spring.infra.error.exceptions.mypage.TokenSaveFailedException;
 import com.grepp.spring.infra.response.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
@@ -45,6 +48,15 @@ public class MyPageExceptionAdvice {
     return ResponseEntity.status(ex.getCode().status())
         .body(ApiResponse.error(ex.getCode()));
   }
+
+  @ExceptionHandler(InvalidPublicCalendarIdException.class)
+  public ResponseEntity<ApiResponse<String>> invalidPublicCalendarIdExHandler(
+      InvalidPublicCalendarIdException ex) {
+
+    return ResponseEntity.status(ex.getCode().status())
+        .body(ApiResponse.error(ex.getCode()));
+  }
+
   // 401
   @ExceptionHandler(AuthenticationRequiredException.class) // 멤버 인증 관련
   public ResponseEntity<ApiResponse<String>> authenticationRequiredExHandler(
@@ -63,7 +75,7 @@ public class MyPageExceptionAdvice {
   }
 
   @ExceptionHandler(CalendarAuthRequiredException.class)
-  public ResponseEntity<ApiResponse<String>> handleCalendarAuthRequiredExHandler(
+  public ResponseEntity<ApiResponse<String>> CalendarAuthRequiredExHandler(
       CalendarAuthRequiredException ex) {
 
     return ResponseEntity
@@ -72,7 +84,7 @@ public class MyPageExceptionAdvice {
   }
 
   @ExceptionHandler(CalendarTokenExpiredException.class)
-  public ResponseEntity<ApiResponse<String>> handleCalendarTokenExpiredExHandler(
+  public ResponseEntity<ApiResponse<String>> CalendarTokenExpiredExHandler(
       CalendarTokenExpiredException ex) {
     return ResponseEntity
         .status(ex.getCode().status())
@@ -91,6 +103,14 @@ public class MyPageExceptionAdvice {
   @ExceptionHandler(MemberNotFoundException.class) // 멤버 관련
   public ResponseEntity<ApiResponse<String>> memberNotFoundExHandlerExHandler(
       MemberNotFoundException ex) {
+
+    return ResponseEntity.status(ex.getCode().status())
+        .body(ApiResponse.error(ex.getCode()));
+  }
+
+  @ExceptionHandler(PublicCalendarIdNotFoundException.class)
+  public ResponseEntity<ApiResponse<String>> publicCalendarIdNotFoundException(
+      PublicCalendarIdNotFoundException ex) {
 
     return ResponseEntity.status(ex.getCode().status())
         .body(ApiResponse.error(ex.getCode()));
@@ -141,6 +161,15 @@ public class MyPageExceptionAdvice {
   @ExceptionHandler(FavoriteSaveFailedException.class)
   public ResponseEntity<ApiResponse<String>> FavoriteSaveFailedExHandler(
       FavoriteSaveFailedException ex) {
+
+    return ResponseEntity.status(ex.getCode().status())
+        .body(ApiResponse.error(ex.getCode()));
+  }
+
+  // 503
+  @ExceptionHandler(GoogleCalendarApiFailedException.class)
+  public ResponseEntity<ApiResponse<String>> GoogleCalendarApiExHandler(
+      GoogleCalendarApiFailedException ex) {
 
     return ResponseEntity.status(ex.getCode().status())
         .body(ApiResponse.error(ex.getCode()));

--- a/src/main/java/com/grepp/spring/infra/response/MyPageErrorCode.java
+++ b/src/main/java/com/grepp/spring/infra/response/MyPageErrorCode.java
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus;
 public enum MyPageErrorCode {
   INVALID_FAVORITE_REQUEST("400", HttpStatus.BAD_REQUEST, "잘못된 즐겨찾기 요청입니다."),
   INVALID_MEMBER_REQUEST("400", HttpStatus.BAD_REQUEST, "잘못된 회원 요청입니다."),
+  INVALID_PUBLIC_CALENDAR_ID("400", HttpStatus.BAD_REQUEST, "유효하지 않은 공개 캘린더 ID 입니다."),
   AUTHENTICATION_REQUIRED("401", HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
   GOOGLE_AUTH_FAILED("401", HttpStatus.UNAUTHORIZED, "구글 OAuth 인증에 실패했습니다."),
   // 토큰 없음으로 연동 불가
@@ -14,6 +15,7 @@ public enum MyPageErrorCode {
   // FAVORITE_FORBIDDEN("403", HttpStatus.FORBIDDEN, "해당 즐겨찾기에 대한 권한이 없습니다."),
   FAVORITE_NOT_FOUND("404", HttpStatus.NOT_FOUND, "즐겨찾기를 찾을 수 없습니다."),
   MEMBER_NOT_FOUND("404", HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
+  PUBLIC_CALENDAR_ID_NOT_FOUND("404", HttpStatus.NOT_FOUND, "등록된 공개 캘린더 ID가 없습니다."),
   FAVORITE_ALREADY_EXISTS("409", HttpStatus.CONFLICT, "즐겨찾기가 이미 존재합니다."),
   // 구글 API 호출 실패 (토큰 교환 실패, 네트워크 문제 포함해서)
   CALENDAR_SYNC_FAILED("500", HttpStatus.INTERNAL_SERVER_ERROR, "구글 캘린더 연동에 실패했습니다."),
@@ -21,7 +23,8 @@ public enum MyPageErrorCode {
   INVALID_CALENDAR_RESPONSE("500", HttpStatus.INTERNAL_SERVER_ERROR, "구글 캘린더 응답 데이터가 유효하지 않습니다."),
   CALENDAR_EVENT_SAVE_FAILED("500", HttpStatus.INTERNAL_SERVER_ERROR, "구글 일정 저장 중 오류가 발생했습니다."),
   TOKEN_SAVE_FAILED("500", HttpStatus.INTERNAL_SERVER_ERROR, "구글 인증 토큰 저장에 실패했습니다."),
-  FAVORITE_SAVE_FAILED("500", HttpStatus.INTERNAL_SERVER_ERROR, "즐겨찾기 저장에 실패했습니다.");
+  FAVORITE_SAVE_FAILED("500", HttpStatus.INTERNAL_SERVER_ERROR, "즐겨찾기 저장에 실패했습니다."),
+  GOOGLE_CALENDAR_API_FAILED("503", HttpStatus.SERVICE_UNAVAILABLE, "구글 캘린더 API 호출에 실패했습니다.");
 
   private final String code;
   private final HttpStatus status;


### PR DESCRIPTION

## ✅ 관련 이슈
- close #177 

## 🛠️ 작업 내용
- 등록한 캘린더 ID 조회 기능
- 캘린더 ID 저장 시 구글 API 호출로 유효성 검증
   - null/빈 문자열 저장 차단
- 잘못된 캘린더 ID 및 구글 API 호출 실 상황에 대한 전역 예외 처리 추가  

## 📸 스크린샷 (선택)

<img width="1187" height="801" alt="image" src="https://github.com/user-attachments/assets/8477ff62-3695-47bb-983c-4271ddc61a80" />
공개 캘린더 ID 조회


<img width="1220" height="904" alt="image" src="https://github.com/user-attachments/assets/5bb1a061-00d5-4bfd-bfb5-2a14a0dd9147" />
잘못된 캘린더 ID 로 등록 시

## 🧩 기타 참고사항
- 이전에 사용했던 구글 캘린더 OAuth 관련 필요없는 에러 코드들은 리팩토링 할 때 정리할 예정입니다.
