### PR TITLE
♻️ refactor: 회원 관련 관심사 분리(회원 탈퇴)

### DIFF
--- a/src/main/java/com/grepp/spring/app/model/group/entity/GroupMember.java
+++ b/src/main/java/com/grepp/spring/app/model/group/entity/GroupMember.java
@@ -103,4 +103,9 @@ public class GroupMember extends BaseEntity {
             groupMember.groupAdmin = true;
         }
     }
+
+    // 그룹 관리자 권한 부여
+    public void grantAdminRole() {
+        this.groupAdmin = true;
+    }
 }

--- a/src/main/java/com/grepp/spring/app/model/member/service/MemberService.java
+++ b/src/main/java/com/grepp/spring/app/model/member/service/MemberService.java
@@ -1,35 +1,19 @@
 package com.grepp.spring.app.model.member.service;
 
 import com.grepp.spring.app.controller.api.member.payload.MemberInfoResponse;
-import com.grepp.spring.app.model.auth.code.AuthToken;
-import com.grepp.spring.app.model.auth.token.RefreshTokenService;
-import com.grepp.spring.app.model.group.entity.Group;
-import com.grepp.spring.app.model.group.entity.GroupMember;
-import com.grepp.spring.app.model.group.repository.GroupMemberRepository;
-import com.grepp.spring.app.model.group.repository.GroupRepository;
+import com.grepp.spring.app.model.auth.AuthService;
 import com.grepp.spring.app.controller.api.member.payload.ModifyMemberInfoResponse;
+import com.grepp.spring.app.model.group.service.GroupCommandService;
 import com.grepp.spring.app.model.member.entity.Member;
 import com.grepp.spring.app.model.member.repository.MemberRepository;
-import com.grepp.spring.app.model.schedule.code.ScheduleRole;
-import com.grepp.spring.app.model.schedule.entity.Schedule;
-import com.grepp.spring.app.model.schedule.entity.ScheduleMember;
-import com.grepp.spring.app.model.schedule.repository.ScheduleCommandRepository;
-import com.grepp.spring.app.model.schedule.repository.ScheduleMemberRepository;
-import com.grepp.spring.infra.auth.jwt.JwtTokenProvider;
-import com.grepp.spring.infra.auth.jwt.TokenCookieFactory;
-import com.grepp.spring.infra.error.exceptions.member.WithdrawNotAllowedException;
+import com.grepp.spring.app.model.schedule.service.ScheduleCommandService;
 import com.grepp.spring.infra.error.exceptions.mypage.MemberNotFoundException;
 import com.grepp.spring.infra.response.MyPageErrorCode;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
-import java.util.Random;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -40,12 +24,9 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberService {
 
     private final MemberRepository memberRepository;
-    private final GroupMemberRepository groupMemberRepository;
-    private final GroupRepository groupRepository;
-    private final ScheduleMemberRepository scheduleMemberRepository;
-    private final ScheduleCommandRepository scheduleCommandRepository;
-    private final JwtTokenProvider jwtTokenProvider;
-    private final RefreshTokenService refreshTokenService;
+    private final AuthService authService;
+    private final GroupCommandService groupCommandService;
+    private final ScheduleCommandService scheduleCommandService;
 
     public Optional<Member> findById(String userId) {
         return memberRepository.findById(userId);
@@ -58,108 +39,6 @@ public class MemberService {
             .orElseThrow(() -> new MemberNotFoundException(MyPageErrorCode.MEMBER_NOT_FOUND)); // 서윤님이 만든 예외 쓰기. 나중에 전역 처리 해야함
 
         return MemberInfoResponse.from(member);
-    }
-
-    @Transactional
-    public void withdraw(String userId, HttpServletResponse response, HttpServletRequest request) {
-        Member member = memberRepository.findById(userId)
-            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
-        // 이 사람이 그룹의 관리자인지를 체크
-        // 관리자라면 이 사람이 관리자인 그룹을 전부 조회
-
-        // 본인이 관리자인 그룹 조회
-        List<Group> adminGroups = groupMemberRepository.findGroupsByMemberAndAdmin(member);
-        // 예외처리에 사용할 수퍼 리더를 넘길 수 없는 그룹을 저장할 리스트
-        List<Group> withdrawNotAllowedGroups = new ArrayList<>();
-        // 본인이 수퍼 리더(Admin)인 그룹이 있다면, 각 그룹 별 리더 중 랜덤으로 권한 넘기기
-        if (!adminGroups.isEmpty()){
-            for (Group group : adminGroups){
-                // 각 그룹의 모든 멤바 조회
-                List<GroupMember> groupMembers = groupMemberRepository.findByGroup(group);
-                // 내가 그룹의 유일한 멤바라면 그룹까지 날려버리깅
-                if (groupMembers.size() == 1 && groupMembers.getFirst().getMember().equals(member)){
-                    groupRepository.delete(group);
-                    log.info("그룹 {}의 유일한 멤버이므로 그룹이 삭제됩니다.", group.getName());
-                    continue;
-                }
-
-                // 각 그룹의 모든 리더 조회 (나 빼고)
-                List<GroupMember> groupLeaders = groupMemberRepository.findByGroupAndLeaderAndMemberNot(group, member);
-                // 본인 외 다른 멤바가 있다면?
-                if (!groupLeaders.isEmpty()){
-                    // 리더가 존재한다면 랜덤으로 관리자 넘겨버리깅
-                    GroupMember newAdmin = selectRandomMember(groupLeaders);
-
-                    newAdmin.setGroupAdmin(true); // 너 이제부터 수퍼리더야.
-                    groupMemberRepository.save(newAdmin);
-                    log.info("그룹 {}의 새 관리자가 {} 님 에게 위임되었습니다.", group.getName(), newAdmin.getMember().getName());
-                }else {
-                    // 리더가 없으면 예외 발생 시켜야하니깐 그룹을 리스트에 추가해두자. 나중에 응답에 쓸거임
-                    withdrawNotAllowedGroups.add(group);
-                    log.info("위임할 리더가 없는 그룹: {}", group.getName());
-                }
-            }
-        }
-        // 수퍼 리더 위임이 불가능한 그룹이 있다면 예외처리
-        // 탈퇴 전에 그룹에 리더를 만들어야 해요~~!!
-        if (!withdrawNotAllowedGroups.isEmpty()){
-            throw new WithdrawNotAllowedException("이 그룹에 관리자 권한을 위임할 수 있는 리더를 추가해주세요.", withdrawNotAllowedGroups);
-        }
-
-        // 일정 관리자 처리
-        // 본인이 일정 마스터인 모든 일정 조회
-        List<Schedule> masterSchedules = scheduleMemberRepository.findByMember(member);
-
-        // 본인이 마스터인 일정이 있다면,
-        if (!masterSchedules.isEmpty()){
-            for (Schedule schedule : masterSchedules){
-                // 각 일정 내 모든 멤바 조회 (나 빼고)
-                List<ScheduleMember> scheduleMembers = scheduleMemberRepository.findByScheduleAndMemberNot(schedule, member);
-
-                if (scheduleMembers.isEmpty()){
-                    // 본인이 일정의 유일 멤버라면? 일정 너도 삭제야.
-                    scheduleCommandRepository.delete(schedule);
-                    log.info("일정 {}의 마지막 멤버이므로 일정이 삭제됩니다.", schedule.getScheduleName());
-                } else {
-                    // 다른 멤바가 있다면 랜덤으로 관리자 위임
-                    ScheduleMember newScheduleMaster = selectRandomMember(scheduleMembers);
-                    newScheduleMaster.setRole(ScheduleRole.ROLE_MASTER); // 새 관리자로 임명
-                    scheduleMemberRepository.save(newScheduleMaster);
-                    log.info("일정 {}의 새 관리자가 {}님 에게 위임되었습니다.", schedule.getScheduleName(),newScheduleMaster.getMember().getName());
-                }
-            }
-        }
-
-        // 이제 진짜 탈퇴.
-        memberRepository.delete(member);
-        log.info("회원 탈퇴가 완료되었습니다. 회원 ID: {}, 회원명: {}", member.getId(), member.getName());
-
-        // 쿠키에서 토큰 제거
-        ResponseCookie deleteAccessTokenCookie = TokenCookieFactory.createExpiredToken(AuthToken.ACCESS_TOKEN.name());
-        response.addHeader(HttpHeaders.SET_COOKIE, deleteAccessTokenCookie.toString());
-
-        ResponseCookie deleteRefreshTokenCookie = TokenCookieFactory.createExpiredToken(AuthToken.REFRESH_TOKEN.name());
-        response.addHeader(HttpHeaders.SET_COOKIE, deleteRefreshTokenCookie.toString());
-
-        ResponseCookie deleteSessionIdCookie = TokenCookieFactory.createExpiredToken(AuthToken.AUTH_SERVER_SESSION_ID.name());
-        response.addHeader(HttpHeaders.SET_COOKIE, deleteSessionIdCookie.toString());
-
-        // Redis에서 리프레시 토큰 제거
-        String accessToken = jwtTokenProvider.resolveToken(request, AuthToken.ACCESS_TOKEN);
-        if (accessToken != null && jwtTokenProvider.validateToken(accessToken)) {
-            String atJti = jwtTokenProvider.getClaims(accessToken).getId();
-            refreshTokenService.deleteByAccessTokenId(atJti);
-        }
-
-        SecurityContextHolder.clearContext();
-        log.info("탈퇴한 회원이므로 자동으로 로그아웃됩니다.");
-    }
-
-    // 다음 리더를 뽑아주는 제네릭 메서드 : 이렇게 하면 그룹이랑 스케줄에서 같이 쓸 수 있습니다
-    private <T> T selectRandomMember(List<T> members) {
-        Random random = new Random();
-        int randomIndex = random.nextInt(members.size());
-        return members.get(randomIndex);
     }
 
     // 이름 변경
@@ -189,5 +68,22 @@ public class MemberService {
         log.info("프로필 이미지가 변경되었습니다. 새로운 이미지 번호: {}", member.getProfileImageNumber());
 
         return new ModifyMemberInfoResponse(member.getId(), member.getName(), member.getProfileImageNumber());
+    }
+
+    // 회원 탈퇴
+    @Transactional
+    public void withdraw(String userId, HttpServletResponse response, HttpServletRequest request) {
+        Member member = memberRepository.findById(userId)
+            .orElseThrow(() -> new MemberNotFoundException(MyPageErrorCode.MEMBER_NOT_FOUND));
+        // 1. 그룹 관련
+        groupCommandService.handleGroupWithdrawal(member);
+        // 2. 일정 관련
+        scheduleCommandService.handleScheduleWithdrawal(member);
+        // 3. 회원 탈퇴(삭제)
+        memberRepository.delete(member);
+        log.info("회원 탈퇴가 완료되었습니다. 회원 ID: {}, 회원명: {}", member.getId(), member.getName());
+        // 4. 로그아웃 (토큰 무효화)
+        authService.logout(request, response); // 다른 서비스 참조. 괜찮은가 ?
+        SecurityContextHolder.clearContext();
     }
 }

--- a/src/main/java/com/grepp/spring/app/model/schedule/entity/ScheduleMember.java
+++ b/src/main/java/com/grepp/spring/app/model/schedule/entity/ScheduleMember.java
@@ -15,7 +15,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
-import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import java.util.ArrayList;
 import java.util.List;
@@ -67,4 +66,9 @@ public class ScheduleMember extends BaseEntity {
     // ScheduleMember 가 삭제되면 그 멤버의 투표도 삭제
     @OneToMany(mappedBy = "scheduleMember", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Vote> votes = new ArrayList<>();
+
+    // 일정 마스터 권한 부여
+    public void grantMasterRole() {
+        this.role = ScheduleRole.ROLE_MASTER;
+    }
 }

--- a/src/main/java/com/grepp/spring/infra/error/memberAdvice/AuthExceptionAdvice.java
+++ b/src/main/java/com/grepp/spring/infra/error/memberAdvice/AuthExceptionAdvice.java
@@ -1,4 +1,4 @@
-package com.grepp.spring.infra.error;
+package com.grepp.spring.infra.error.memberAdvice;
 
 import com.grepp.spring.infra.error.exceptions.AuthApiException;
 import com.grepp.spring.infra.response.ApiResponse;

--- a/src/main/java/com/grepp/spring/infra/error/memberAdvice/MemberExceptionAdvice.java
+++ b/src/main/java/com/grepp/spring/infra/error/memberAdvice/MemberExceptionAdvice.java
@@ -1,12 +1,13 @@
-package com.grepp.spring.infra.error;
+package com.grepp.spring.infra.error.memberAdvice;
 
 import com.grepp.spring.app.controller.api.auth.payload.response.GroupAdminResponse;
 import com.grepp.spring.infra.error.exceptions.member.InvalidNameException;
 import com.grepp.spring.infra.error.exceptions.member.WithdrawNotAllowedException;
+import com.grepp.spring.infra.error.exceptions.mypage.MemberNotFoundException;
 import com.grepp.spring.infra.response.ApiResponse;
+import com.grepp.spring.infra.response.MyPageErrorCode;
 import com.grepp.spring.infra.response.ResponseCode;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -21,14 +22,20 @@ public class MemberExceptionAdvice {
             .map(group -> new GroupAdminResponse(group.getId(), group.getName()))
             .toList();
 
-        return ResponseEntity.status(403)
+        return ResponseEntity.status(ResponseCode.NOT_ALLOWED_WITHDRAW.status())
             .body(ApiResponse.error(ResponseCode.NOT_ALLOWED_WITHDRAW, groups));
     }
 
     @ExceptionHandler(InvalidNameException.class)
     public ResponseEntity<ApiResponse<Void>> invalidNameExHandler(InvalidNameException ex) {
-        return ResponseEntity.status(400)
+        return ResponseEntity.status(ResponseCode.BAD_REQUEST.status())
             .body(ApiResponse.error(ResponseCode.BAD_REQUEST, ex.getMessage()));
+    }
+
+    @ExceptionHandler(MemberNotFoundException.class)
+    public ResponseEntity<ApiResponse<String>> memberNotFoundExHandler(MemberNotFoundException ex) {
+        return ResponseEntity.status(MyPageErrorCode.MEMBER_NOT_FOUND.status())
+            .body(ApiResponse.error(MyPageErrorCode.MEMBER_NOT_FOUND, MyPageErrorCode.MEMBER_NOT_FOUND.message()));
     }
 
 }

--- a/src/main/java/com/grepp/spring/infra/utils/RandomPicker.java
+++ b/src/main/java/com/grepp/spring/infra/utils/RandomPicker.java
@@ -1,4 +1,4 @@
-package com.grepp.spring.infra;
+package com.grepp.spring.infra.utils;
 
 import java.util.List;
 import java.util.Random;


### PR DESCRIPTION
## ✅ 관련 이슈
- close #183 

## 🛠️ 작업 내용
- 회원 탈퇴 기능을 다음과 같은 세부 메서드로 분리했습니다.
  - 그룹 관련 처리(조건부 삭제 및 권한 위임, 예외 발생) > GroupCommandService로 이동 후 참조
  - 일정 관련 처리(조건부 삭제 및 권한 위임) > ScheduleCommandService로 이동 후 참조
  - 회원 탈퇴
  - 로그아웃 및 토큰 무효화(AuthService 참조)
  - 위임 대상 랜덤 선정 메서드 >> Utils 로 분리
- 일부 메서드를 타 Service 레이어로 이동함과 동시에, 엔티티로 책임을 넘길 수 있도록 권한 부여 메서드를 생성했습니다. 
   - GroupMember, ScheduleMember 각각 생성




## 📸 스크린샷
- ScheduleMember에서의 일정 마스터 권한 부여 메서드
<img width="469" height="170" alt="image" src="https://github.com/user-attachments/assets/56f60b6c-e378-43fd-bb07-0cd0d67aa19d" />

- GroupMember에서의 그룹 관리자 권한 부여 메서드
<img width="388" height="104" alt="image" src="https://github.com/user-attachments/assets/0eacaaa0-8380-4909-8edd-6dedd7890c76" />

## 🧩 기타 참고사항
- 추후 각 서비스에서 통합이 가능한 메서드들을 통합하면 좋을 듯합니다!
작업을 따로 진행했다보니, 아직 온전히 통일되지 못한 부분이 남아있습니다.
