### PR TITLE
✨ feat: 메인페이지 내부 일정 목록 조회용 API

### DIFF
--- a/src/main/java/com/grepp/spring/app/controller/api/mainpage/MainPageController.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/mainpage/MainPageController.java
@@ -32,7 +32,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/main-page")
 public class MainPageController {
 
-  @Autowired
   private final MainPageService mainPageService;
 
   private final MainPageScheduleMemberService mainPageScheduleMemberService;
@@ -76,6 +75,20 @@ public class MainPageController {
     response.put("groupedSchedules", groupedByDate);
 
     return ApiResponse.success("월간 일정 조회 성공", groupedByDate);
+  }
+
+  @Operation(summary = "내부 일정 목록만 조회하는 기능")
+  @GetMapping("/schedules")
+  public ApiResponse<List<UnifiedScheduleDto>> getScheduleLists(
+      @CurrentUser String userId,
+      @RequestParam LocalDate startDate,
+      @RequestParam LocalDate endDate
+  ) {
+
+    List<UnifiedScheduleDto> schedules = mainPageService.getInternalSchedules(userId, startDate, endDate);
+
+    return ApiResponse.success(schedules);
+
   }
 
   @Operation(summary = "일정 비활성화 기능")

--- a/src/main/java/com/grepp/spring/app/controller/api/mainpage/payload/response/ShowMainPageResponse.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/mainpage/payload/response/ShowMainPageResponse.java
@@ -11,7 +11,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-@Getter @Setter
+@Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -27,7 +27,6 @@ public class ShowMainPageResponse {
 
   // 주간 일정을 담는 내부 클래스
   @Getter
-  @Setter
   @NoArgsConstructor
   @AllArgsConstructor
   @Builder


### PR DESCRIPTION

메인페이지 내부 일정 목록 조회용 API

## ✅ 관련 이슈
- close #205 

## 🛠️ 작업 내용
- 내부 일정만 조회하는 API 
  - `GET /api/v1/main-page/schedules`
  - 날짜 범위 지정하여 보여주는 캘린더 api 와 마찬가지로 선택된 기간 동안 내부 일정 조회
- convertSchedulesToDtos 메서드 
  -  schedule -> UnifiedScheduleDto 변환 로직 공통화
- 구글 일정 필터링 로직 메서드 분리
  - isWithinRange() : 종일 일정 (AllDay) 여부 판단 + 조회 범위에 일정이 겹치는지 판단

## 📸 스크린샷 (선택)
<img width="1150" height="931" alt="image" src="https://github.com/user-attachments/assets/d5525410-ed44-42be-ae2e-e260941ca350" />


## 🧩 기타 참고사항

