### PR TITLE
♻️ refactor: 메인페이지 날짜 지정 일정 조회 API 수정

### DIFF
--- a/src/main/java/com/grepp/spring/app/controller/api/mainpage/MainPageController.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/mainpage/MainPageController.java
@@ -55,7 +55,7 @@ public class MainPageController {
 
   @Operation(summary = "날짜 범위 지정 (내부 + 구글 공개) 일정 통합 조회 (메인페이지 확장)")
   @GetMapping("/calendar")
-  public ApiResponse<Map<LocalDate,List<UnifiedScheduleDto>>> getSchedulesInRange(
+  public  ResponseEntity<ApiResponse<Map<String, Object>>> getSchedulesInRange(
       @CurrentUser String userId,
       @RequestParam LocalDate startDate,
       @RequestParam LocalDate endDate
@@ -73,8 +73,9 @@ public class MainPageController {
     Map<String, Object> response = new HashMap<>();
     response.put("googleCalendarFetchSuccess", result.isGoogleFetchSuccess());
     response.put("groupedSchedules", groupedByDate);
+    response.put("groupDetails", result.getGroups()); // 그룹 정보
 
-    return ApiResponse.success("월간 일정 조회 성공", groupedByDate);
+    return  ResponseEntity.ok(ApiResponse.success(response));
   }
 
   @Operation(summary = "내부 일정 목록만 조회하는 기능")

--- a/src/main/java/com/grepp/spring/app/model/mainpage/repository/MainPageScheduleRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/mainpage/repository/MainPageScheduleRepository.java
@@ -1,5 +1,6 @@
 package com.grepp.spring.app.model.mainpage.repository;
 
+import com.grepp.spring.app.model.schedule.code.ScheduleStatus;
 import com.grepp.spring.app.model.schedule.entity.Schedule;
 import java.time.LocalDateTime;
 import java.util.List;

--- a/src/main/java/com/grepp/spring/app/model/mainpage/service/MainPageService.java
+++ b/src/main/java/com/grepp/spring/app/model/mainpage/service/MainPageService.java
@@ -2,12 +2,14 @@ package com.grepp.spring.app.model.mainpage.service;
 
 import com.grepp.spring.app.controller.api.group.payload.response.ShowGroupResponse;
 import com.grepp.spring.app.controller.api.mainpage.payload.response.ShowMainPageResponse;
+import com.grepp.spring.app.model.group.dto.GroupDetailDto;
 import com.grepp.spring.app.model.group.entity.Group;
 import com.grepp.spring.app.model.group.service.GroupQueryMainpageService;
 import com.grepp.spring.app.model.mainpage.dto.UnifiedScheduleDto;
 import com.grepp.spring.app.model.member.repository.MemberRepository;
 import com.grepp.spring.app.model.mypage.dto.PublicCalendarEventDto;
 import com.grepp.spring.app.model.mypage.service.PublicCalendarIdService;
+import com.grepp.spring.app.model.schedule.code.ScheduleStatus;
 import com.grepp.spring.app.model.schedule.entity.Schedule;
 import com.grepp.spring.app.model.schedule.entity.ScheduleMember;
 import com.grepp.spring.app.model.schedule.repository.ScheduleMemberRepository;
@@ -50,6 +52,7 @@ public class MainPageService { // 메인페이지 & 달력 (구글 일정 + 내�
   @AllArgsConstructor
   public static class UnifiedScheduleResult {
     private final List<UnifiedScheduleDto> schedules;
+    private final List<GroupDetailDto> groups;
     private final boolean googleFetchSuccess;
   }
   @Transactional(readOnly = true)
@@ -97,6 +100,10 @@ public class MainPageService { // 메인페이지 & 달력 (구글 일정 + 내�
   public UnifiedScheduleResult getUnifiedSchedules(String memberId, LocalDate start,
       LocalDate end) {
 
+    // 그룹 정보 가져오기
+    ShowGroupResponse groupResponse = groupQueryMainpageService.displayGroup();
+    List<GroupDetailDto> groups = groupResponse.getGroupDetails();
+
     LocalDateTime startDateTime = start.atStartOfDay();
     LocalDateTime endDateTime = end.atTime(23, 59, 59);
 
@@ -115,7 +122,7 @@ public class MainPageService { // 메인페이지 & 달력 (구글 일정 + 내�
     // 공개 캘린더 ID 없으면 내부 일정만 반환
     if (publicCalendarIdOpt.isEmpty()) {
       log.info("공개 캘린더 ID 없음 → 내부 일정만 반환");
-      return new UnifiedScheduleResult(internalDtos, true);
+      return new UnifiedScheduleResult(internalDtos, groups,true);
     }
 
 
@@ -148,13 +155,13 @@ public class MainPageService { // 메인페이지 & 달력 (구글 일정 + 내�
           .toList();
 
       // 구글까지 성공적으로 가져온 경우 → success=true
-      return new UnifiedScheduleResult(merged, true);
+      return new UnifiedScheduleResult(merged, groups,true);
 
     } catch (InvalidPublicCalendarIdException e) {
-      return new UnifiedScheduleResult(internalDtos, false);
+      return new UnifiedScheduleResult(internalDtos, groups,false);
 
     } catch (GoogleCalendarApiFailedException e) {
-      return new UnifiedScheduleResult(internalDtos, false);
+      return new UnifiedScheduleResult(internalDtos, groups,false);
 
     }
   }
@@ -170,6 +177,11 @@ public class MainPageService { // 메인페이지 & 달력 (구글 일정 + 내�
 
   private List<UnifiedScheduleDto> convertSchedulesToDtos(List<Schedule> schedules, String memberId) {
     return schedules.stream()
+        // l_recommend, e_recommend 걸러주기
+        .filter(schedule -> {
+          ScheduleStatus status = schedule.getStatus();
+          return status == ScheduleStatus.FIXED || status == ScheduleStatus.COMPLETE;
+        })
         .map(schedule -> {
           Group group = schedule.getEvent().getGroup();
           List<ScheduleMember> participants = schedule.getScheduleMembers();


### PR DESCRIPTION


## ✅ 관련 이슈
- close #208

## 🛠️ 작업 내용
- 날짜 지정 일정 조회 API 응답 데이터에 그룹 정보 추가
   - 기존에 썼던 오늘 날짜 기준 조회 API 쓰지 않고 해당 API 로 공통으로 사용
- 일정 조회 시 ScheduleStatus 가 `FIXED` , `COMPLETE` 인 일정만 조회되게끔 필터링

## 📸 스크린샷 (선택)


<img width="1119" height="888" alt="image" src="https://github.com/user-attachments/assets/dae7abe6-e3d2-49f2-8bc1-b5535cee719a" />
날짜 범위 지정 일정 조회 api 에 그룹 정보 및 googleFetchSuccess 데이터 추가



## 🧩 기타 참고사항

