### PR TITLE
♻️ refactor: 비관적 락으로 다수가 동시에 투표하는 상황에서 발생하는 동시성 문제 해결

### DIFF
--- a/src/main/java/com/grepp/spring/app/model/schedule/repository/LocationQueryRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/schedule/repository/LocationQueryRepository.java
@@ -1,8 +1,11 @@
 package com.grepp.spring.app.model.schedule.repository;
 
 import com.grepp.spring.app.model.schedule.entity.Location;
+import jakarta.persistence.LockModeType;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -10,4 +13,8 @@ public interface LocationQueryRepository extends JpaRepository<Location, Long> {
 
     @Query("SELECT l FROM Location l where l.schedule.id = :scheduleId")
     List<Location> findByScheduleId(@Param("scheduleId") Long scheduleId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select l from Location l where l.id = :id")
+    Optional<Location> findByIdWithPessimisticLock(@Param("id") Long id);
 }

--- a/src/test/java/com/grepp/spring/app/model/schedule/service/ScheduleCommandServiceTest.java
+++ b/src/test/java/com/grepp/spring/app/model/schedule/service/ScheduleCommandServiceTest.java
@@ -1,0 +1,230 @@
+package com.grepp.spring.app.model.schedule.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.grepp.spring.app.model.schedule.code.VoteStatus;
+import com.grepp.spring.app.model.schedule.entity.Location;
+import com.grepp.spring.app.model.schedule.entity.Schedule;
+import com.grepp.spring.app.model.schedule.entity.ScheduleMember;
+import com.grepp.spring.app.model.schedule.repository.LocationQueryRepository;
+import com.grepp.spring.app.model.schedule.repository.ScheduleCommandRepository;
+import com.grepp.spring.app.model.schedule.repository.ScheduleMemberRepository;
+import com.grepp.spring.app.model.schedule.repository.ScheduleQueryRepository;
+import com.grepp.spring.app.model.schedule.repository.VoteQueryRepository;
+import com.grepp.spring.infra.error.exceptions.schedule.LocationNotFoundException;
+import com.grepp.spring.infra.response.ScheduleErrorCode;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+class ScheduleCommandServiceTest {
+
+    @Autowired
+    private ScheduleCommandService scheduleCommandService;
+
+    @Autowired
+    private LocationQueryRepository locationRepository;
+
+    @Autowired
+    private ScheduleCommandRepository scheduleCommandRepository;
+
+    private Schedule testSchedule;
+    private Location testLocation1;
+    private Location testLocation2;
+    @Autowired
+    private ScheduleMemberRepository scheduleMemberRepository;
+
+    @Autowired
+    private VoteQueryRepository voteQueryRepository;
+
+    @BeforeEach
+    @Transactional
+    void setUp(){
+        // 기존의 데이터 정리
+        scheduleCommandRepository.deleteAll();
+        scheduleMemberRepository.deleteAll();
+        locationRepository.deleteAll();
+
+        // 테스트를 위한 Schedule 생성
+        testSchedule = new Schedule();
+        testSchedule.setScheduleName("테스트 스케줄");
+        testSchedule = scheduleCommandRepository.save(testSchedule);
+
+        // 테스트를 위한 Location 생성
+        testLocation1 = new Location();
+        testLocation1.setSchedule(testSchedule);
+        testLocation1.setLatitude(37.55315);
+        testLocation1.setLongitude(126.972533);
+        testLocation1.setName("테스트 장소 1");
+        testLocation1.setVoteCount(0);
+        testLocation1.setStatus(VoteStatus.DEFAULT);
+        testLocation1 = locationRepository.save(testLocation1);
+
+        testLocation2 = new Location();
+        testLocation2.setSchedule(testSchedule);
+        testLocation2.setLatitude(37.55315);
+        testLocation2.setLongitude(126.972533);
+        testLocation2.setName("테스트 장소 1");
+        testLocation2.setVoteCount(0);
+        testLocation2.setStatus(VoteStatus.DEFAULT);
+        testLocation2 = locationRepository.save(testLocation2);
+
+        // 테스트를 위한 ScheduleMember 생성
+        for (int i = 0; i < 100; i++) {
+            ScheduleMember member = new ScheduleMember();
+            member.setSchedule(testSchedule);
+            member.setName("참여자" + i);
+            scheduleMemberRepository.save(member);
+        }
+    }
+
+    @Test
+    @DisplayName("10명이 동시에 투표 진행 시 득표율이 정확히 증가하는지에 대한 테스트")
+    void voteMiddleLocation() throws InterruptedException {
+        final int threads = 100; // 동시에 투표할 사용자 수
+        ExecutorService executorService = Executors.newFixedThreadPool(threads);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch endLatch = new CountDownLatch(threads);
+
+        final Long locationId = testLocation1.getId();
+        assertThat(locationId).isNotNull();
+
+        System.out.println("테스트 시작: " + locationId + "번 장소에 " + threads + "명 동시 투표");
+        System.out.println("초기 voteCnt: " + testLocation1.getVoteCount());
+        // 모든 스케줄 멤버를 각 스레스에 할당
+        List<ScheduleMember> members = scheduleMemberRepository.findAllBySchedule(testSchedule);
+
+        if (members.size() < threads) {
+            fail("테스트에 필요한 일정의 멤버 수가 부족합니다.");
+        }
+
+
+        for (int i = 0; i < threads; i++) {
+            final int memberIndex = i;
+            final ScheduleMember currentMember = members.get(memberIndex);
+
+            executorService.submit(() -> {
+                try {
+                    startLatch.await(); // 모든 스레드가 여기서 대기 후 동시에 시작
+
+                    // 투표 메서드 호출 -> 아마 여기서 문제가 생길 듯?
+                    scheduleCommandService.voteMiddleLocation(testSchedule, currentMember, testLocation1);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    System.err.println(Thread.currentThread().getName() + " -인터럽트 발생: " + e.getMessage());
+                } catch (Exception e) {
+                    System.err.println(Thread.currentThread().getName() + "- 오류 발생" + e.getMessage());
+                } finally {
+                    endLatch.countDown(); // 스레드 완료 시점
+                }
+            });
+        }
+
+        startLatch.countDown(); // 모든 스레드가 동시에 시작
+        executorService.shutdown(); // 스레드 풀 셧다운
+
+        // 모든 스레드가 작업을 완료할 때까지 최대 60초 대기
+        boolean finished = endLatch.await(60, TimeUnit.SECONDS);
+        // 모든 스레드가 시간 내에 종료되었는지 체크
+        assertTrue(finished);
+
+        // 최종 데이터 검증
+        // 트랜젝션 종료 후 DB에 반영된 값을 다시 조회
+
+        Location finalLocation = locationRepository.findById(testLocation1.getId())
+            .orElseThrow(() -> new LocationNotFoundException(ScheduleErrorCode.LOCATION_NOT_FOUND));
+
+        System.out.println("기대하는 최종 득표율: " + threads);
+        System.out.println("실제 DB에 반영된 득표율: " + finalLocation.getVoteCount());
+
+        // 득표율이 예상 값보다 작거나 다른지 확인
+        assertThat(finalLocation.getVoteCount()).isLessThan(threads);
+
+    }
+
+    @Test
+    @DisplayName("비관적 락 환경에서 서로 다른 장소 동시 투표 시 데드락 발생 여부 테스트")
+    void deadlockOnMultipleLocation() throws InterruptedException {
+        final int threads = 100;
+
+        ExecutorService executorService = Executors.newFixedThreadPool(threads);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch endLatch = new CountDownLatch(threads);
+
+        // 총 투표 수
+        int expectedTotalVotes = threads;
+
+        List<ScheduleMember> members = scheduleMemberRepository.findAllBySchedule(testSchedule);
+        if (members.size() < threads) {
+            fail("테스트에 필요한 일정의 멤버 수가 부족합니다.");
+        }
+
+        for (int i = 0; i < threads; i++) {
+            final int memberIndex = i;
+            final ScheduleMember currentMember = members.get(memberIndex);
+
+            final Location targetLocation = (i % 2 == 0) ? testLocation1 : testLocation2;
+
+            executorService.submit(() -> {
+                try {
+                    startLatch.await();
+
+                    scheduleCommandService.voteMiddleLocation(testSchedule, currentMember, targetLocation);
+
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    System.err.println(Thread.currentThread().getName() + " - 인터럽트 발생: " + e.getMessage());
+                } catch (Exception e) {
+                    // 데드락이나 다른 SQL 예외가 발생할 것으로 예상
+                    System.err.println(Thread.currentThread().getName() + " - 오류 발생: " + e.getMessage());
+                    e.printStackTrace(); // 스택 트레이스 출력하여 데드락 확인
+                } finally {
+                    endLatch.countDown(); // 스레드 완료 시점
+                }
+            });
+        }
+
+        startLatch.countDown(); // 모든 스레드가 동시에 시작
+        executorService.shutdown(); // 스레드 풀 셧다운
+
+        // 모든 스레드가 작업을 완료할 때까지 최대 60초 대기
+        boolean finished = endLatch.await(60, TimeUnit.SECONDS);
+        // 모든 스레드가 시간 내에 종료되었는지 체크
+        assertTrue(finished);
+
+        Location finalLocation1 = locationRepository.findById(testLocation1.getId())
+            .orElseThrow(() -> new IllegalArgumentException("장소 A를 찾을 수 없습니다."));
+        Location finalLocation2 = locationRepository.findById(testLocation2.getId())
+            .orElseThrow(() -> new IllegalArgumentException("장소 B를 찾을 수 없습니다."));
+
+        // 모든 투표 기록의 총 개수 확인 (voteCommandRepository에 의해 저장된 레코드 수)
+        // DTO에 locationId를 포함하도록 변경했으니, voteRepository에서 scheduleId로 전체 투표 기록을 조회
+        long totalVotesInDb = voteQueryRepository.findByScheduleId(testSchedule.getId()).size();
+
+        System.out.println("기대하는 총 투표 수: " + expectedTotalVotes);
+        System.out.println("실제 DB에 반영된 장소 1 투표수: " + finalLocation1.getVoteCount());
+        System.out.println("실제 DB에 반영된 장소 2 투표수: " + finalLocation2.getVoteCount());
+        System.out.println("실제 DB에 저장된 총 투표 기록 수: " + totalVotesInDb);
+        System.out.println("최종 모든 Location의 총 득표율: " + (finalLocation1.getVoteCount() + finalLocation2.getVoteCount()));
+
+        // 검증: 총 투표 기록이 예상보다 적거나, 투표 카운트 합이 예상보다 적을 경우 데드락 문제 증명
+        assertThat(totalVotesInDb).isLessThan(expectedTotalVotes); // 모든 Vote 기록이 저장되지 않았을 수 있음
+        assertThat(finalLocation1.getVoteCount() + finalLocation2.getVoteCount()).isLessThan(expectedTotalVotes); // 득표율 합계가 기대보다 작음
+    }
+
+
+
+
+
+}


### PR DESCRIPTION
## ✅ 관련 이슈
- close #217 

## 🛠️ 작업 내용
- 일정 내 중간장소 선정 과정에서, 다수의 인원이 하나의 장소에 동시에 투표하는 시나리오에 대한 테스트 코드 작성
- 비관적 락 / 낙관적 락을 적용했을 때의 테스트 결과 확인
- 다수의 인원이 여러 장소에 동시에 투표할 때, 정상적으로 결과가 반영되는지에 대한 테스트 코드 작성

## 📸 스크린샷
- 기존 로직에서, 다수가 동시에 한 장소에 투표를 진행할 시 동시성 문제가 발생할 것으로 우려되었습니다.
getVoteCount를 한 뒤 +1을 하는 방식으로, 동시에 여러 트랜잭션이 접근할 시 그 결과를 모두 반영하지 못할 것으로 보입니다.
<img width="943" height="683" alt="스크린샷 2025-07-28 123104" src="https://github.com/user-attachments/assets/c462108d-c5fd-49c6-bd2c-2526927e6182" />

- 위 시나리오에 대한 테스트를 수행한 결과
<img width="1466" height="685" alt="스크린샷 2025-07-28 174303" src="https://github.com/user-attachments/assets/278961c4-83bb-4831-83e2-0c977f587ff7" />
동시에 10명의 사용자가 투표에 참여했을 때, 하나의 트랜잭션만을 반영하는 것을 확인했습니다.<br><br>

- 낙관적 락을 적용할 시
낙관적 락을 적용하게 되는 경우, Location 엔티티에 version 필드를 추가해 상태를 관리할 수 있습니다.
또한 락을 적용하고 싶은 메서드에서 Retryable 어노테이션을 적용함으로써, 락 충돌이나 데드락이 발생한 건에 대해 재시도를 하도록 설정할 수 있습니다.
<img width="684" height="313" alt="image" src="https://github.com/user-attachments/assets/ca312061-3ec9-40c7-a471-3722130a7849" />

이후 테스트에서는 정상적으로 문제 해결이 되는 듯 하였으나,
동시에 요청하는 스레드가 늘어나게 되면 다시 누락되는 투표가 발생했습니다. -> 순차적인 트랜잭션 처리를 보장하지 않기 때문에,
성공할 때까지 Retry를 하는 상황이고, 지정된 try 횟수에 비해 많은 스레드가 할당되면 한계를 보이고 있었습니다.
실제로 maxAttempt 의 값을 늘리면 해결이 가능했지만, 너무 많은 횟수는 오히려 서버에 부하를 일으키거나 사용자 경험을 저하시킬 가능성이 있어 보입니다.

- 비관적 락을 적용 - 10개의 스레드
Location을 조회하는 쿼리에 비관적 락을 거는 방식으로 변경한 뒤 테스트를 진행했습니다.

첫 시도에서는 잘 작동하지 않았고, 데드락이 발생했습니다.
기존 메서드에서는 vote에 대한 save 호출이 일어난 이후 Location에 대한 처리가 되고 있었습니다.
하지만 vote에는 Location이 외래키로 참조되고 있는 상황으로, vote에서 참조 무결성을 보장하기 위해
DB에서는 부모 레코드인 Location에 공유 락을 걸게 됩니다.

이후 다른 트랜잭션에서 Location에 쓰기 락(X-Lock)을 걸게 되면, 두 개의 락이 얽혀 교착 상태(DeadLock)을 유발합니다.

이를 해결하기 위해, 메서드의 호출 순서를 Location -> 이후 vote로 수정하여, 락의 획득 순서를 location > vote로 일관되게 만들었습니다.

<img width="867" height="763" alt="image" src="https://github.com/user-attachments/assets/f35bccdd-0bad-45ea-8767-d131cb3d0a39" />


수정 이후, 10개의 스레드 요청에서는 문제가 잘 해결되는 모습입니다.
<img width="1169" height="410" alt="스크린샷 2025-07-29 112854" src="https://github.com/user-attachments/assets/e3dda1c6-31c3-45aa-a374-ecbddc709b6e" />

다음은 50개의 스레드를 요청한 테스트입니다.
시간은 조금 늘어나지만, 정상적으로 요청을 받아 손실되는 투표가 없습니다.
<img width="1177" height="384" alt="스크린샷 2025-07-29 122930" src="https://github.com/user-attachments/assets/107aa132-1af6-4af1-98f8-e02aeb55761f" />

100개의 스레드를 동시에 요청해보았습니다.
<img width="1506" height="416" alt="스크린샷 2025-07-29 123025" src="https://github.com/user-attachments/assets/0db1f0a5-1c15-4ad7-9c7c-55b01447d569" />

득표율과 같은 경우, 데이터의 무결성을 지키는 것이 중요하다고 판단하여 비관적 락을 적용해 해결하였습니다.

- 비관적 락을 적용했을 때, 서로 다른 장소에 다수가 동시에 투표할 경우
마지막으로 비관적 락을 적용한 후, 서로 다른 장소에 동시에 투표하는 시나리오에 대한 테스트를 진행했습니다.
<img width="1043" height="290" alt="스크린샷 2025-07-29 153508" src="https://github.com/user-attachments/assets/2e30a7fd-ea58-4e53-ab94-66386f1bfe0f" />
각 장소에 50명씩 총 100개의 스레드가 요청되었고, 각각 정확한 값이 저장됨을 확인했습니다.
