### PR TITLE
✨ feat: 이벤트 all-time 조회 성능 개선을 위한 Redis 캐시 도입

### DIFF
--- a/src/main/java/com/grepp/spring/app/model/event/service/EventCommandService.java
+++ b/src/main/java/com/grepp/spring/app/model/event/service/EventCommandService.java
@@ -46,6 +46,7 @@ public class EventCommandService {
     private final TempScheduleRepository tempScheduleRepository;
     private final EventScheduleResultService eventScheduleResultService;
     private final EventCreationStrategyFactory strategyFactory;
+    private final EventScheduleCacheService cacheService;
 
     public CreateEventResponse createEvent(CreateEventRequest webRequest, String currentMemberId) {
         CreateEventDto serviceRequest = CreateEventDto.toDto(webRequest, currentMemberId);
@@ -77,6 +78,8 @@ public class EventCommandService {
 
         EventMemberDto memberDto = EventMemberDto.toDto(dto.getEventId(), dto.getMemberId(), Role.ROLE_MEMBER);
         createEventMember(memberDto);
+
+        cacheService.invalidateEventCache(eventId);
     }
 
     public void createOrUpdateMyTime(MyTimeScheduleRequest request, Long eventId, String currentMemberId) {
@@ -90,6 +93,8 @@ public class EventCommandService {
         for (MyTimeScheduleDto.DailyTimeSlotDto slot : dto.getDailyTimeSlots()) {
             updateOrCreateTempSchedule(eventMember, slot);
         }
+
+        cacheService.invalidateEventCache(eventId);
     }
 
     private void updateOrCreateTempSchedule(EventMember eventMember, MyTimeScheduleDto.DailyTimeSlotDto slot) {
@@ -126,6 +131,8 @@ public class EventCommandService {
 
         eventMember.confirmScheduleOrThrow();
         eventMemberRepository.save(eventMember);
+
+        cacheService.invalidateEventCache(eventId);
     }
 
     public void createScheduleResult(Long eventId, String currentMemberId) {

--- a/src/main/java/com/grepp/spring/app/model/event/service/EventScheduleCacheService.java
+++ b/src/main/java/com/grepp/spring/app/model/event/service/EventScheduleCacheService.java
@@ -1,0 +1,69 @@
+package com.grepp.spring.app.model.event.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.grepp.spring.app.controller.api.event.payload.response.AllTimeScheduleResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class EventScheduleCacheService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    private static final String CACHE_KEY_PREFIX = "event:all-time:";
+
+    private static final Duration DEFAULT_TTL = Duration.ofMinutes(10);
+
+    // 캐시에서 전체 시간대 조회 결과를 가져옴. 캐시 조회 실패 시 null 반환
+    public AllTimeScheduleResponse getCachedAllTimeSchedule(Long eventId) {
+        try {
+            String key = buildCacheKey(eventId);
+            Object cached = redisTemplate.opsForValue().get(key);
+
+            if (cached == null) {
+                return null;
+            }
+
+            AllTimeScheduleResponse response = objectMapper.convertValue(cached, AllTimeScheduleResponse.class);
+
+            if (response != null) {
+                log.debug("Cache hit for eventId: {}", eventId);
+                return response;
+            }
+
+            return null;
+
+        } catch (Exception e) {
+            log.warn("Cache get failed for eventId: {}, falling back to DB: {}", eventId, e.getMessage());
+            return null;
+        }
+    }
+
+    // 전체 시간대 조회 결과를 캐시에 저장
+    public void cacheAllTimeSchedule(Long eventId, AllTimeScheduleResponse response) {
+        String key = buildCacheKey(eventId);
+        redisTemplate.opsForValue().set(key, response, DEFAULT_TTL);
+
+        log.debug("Cached data for eventId: {}", eventId);
+    }
+
+    // 특정 이벤트의 캐시를 무효화
+    public void invalidateEventCache(Long eventId) {
+        String key = buildCacheKey(eventId);
+        Boolean deleted = redisTemplate.delete(key);
+
+        log.debug("Cache invalidated for eventId: {}, deleted: {}", eventId, deleted);
+    }
+
+    // 캐시 키 생성
+    private String buildCacheKey(Long eventId) {
+        return CACHE_KEY_PREFIX + eventId;
+    }
+}


### PR DESCRIPTION
## ✅ 관련 이슈
- close #214 

## 🛠️ 작업 내용
이벤트 참여자 전원의 가능한 시간대 조회(getAllTimeSchedules) API의 성능을 개선하기 위해 Redis 캐시를  적용하여 응답 시간을 단축시켰습니다.
- EventScheduleCacheService 추가
  - 캐시 저장/조회: AllTimeScheduleResponse 객체를 Redis에 캐싱
  - TTL 설정: 10분 캐시 유지
  - 에러 핸들링: 캐시 실패 시 DB 조회로 자동 fallback
- EventQueryService 성능 최적화
  - 캐시 조회 → 캐시 미스 시 DB 조회 → 결과 캐싱
  - 복잡한 집계 쿼리 캐싱: 후보 날짜별 참여자 수 계산, 멤버별 시간표 매핑, 실시간 참여 현황 통계
- 일정 데이터 변경 시 관련 캐시 즉시 무효화(EventCommandService)
  - createOrUpdateMyTime(): 개인 일정 수정 시
  - completeMyTime(): 일정 확정 시
  - joinEvent(): 새 참여자 추가 시

## 📸 스크린샷
- 변경 전/후 API 응답 속도
<img width="3877" height="1031" alt="포스트맨" src="https://github.com/user-attachments/assets/7edc815c-a12e-4e7e-b4ba-65c5fd11ac06" />
- Redis에 저장된 값
<img width="1508" height="503" alt="스크린샷 2025-07-29 오후 3 39 37" src="https://github.com/user-attachments/assets/61831dfd-2a97-42cf-b5eb-f038bcf50966" />
- 로그(좌: 캐시에 저장, 우: 캐시에 저장된 값 조회)
<img width="1048" height="42" alt="디버그" src="https://github.com/user-attachments/assets/643cb1dd-e8b1-4277-bdbb-cd9f70a7e5c3" />

