### PR TITLE
✅ test	멀티스레드 환경에서 동시에 일정 생성 시 동시성 해결

### DIFF
--- a/src/main/java/com/grepp/spring/app/model/event/entity/Event.java
+++ b/src/main/java/com/grepp/spring/app/model/event/entity/Event.java
@@ -40,6 +40,9 @@ public class Event extends BaseEntity {
     @Column(nullable = false)
     private Integer maxMember;
 
+    @Version
+    private Long version = 0L;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "team_id")
     private Group group;

--- a/src/main/resources/testForScheduleRegist.sql
+++ b/src/main/resources/testForScheduleRegist.sql
@@ -1,0 +1,77 @@
+-- 그룹 테이블 생성
+insert into teams(id, name, description, is_grouped, activated)
+values (1,'DOD 그룹','DOD 그룹입니당',true, true);
+
+
+
+show engine innodb status;
+
+-- 이벤트 테이블 생성
+insert into events(id, description, max_member, meeting_type, title, team_id, activated)
+values (4,'일정 생성 이벤트', 10, 'OFFLINE', 'DOD 이벤트', 1, true);
+
+-- 멤버 테이블 생성
+insert into members(id, password, provider, role, email, name, profile_image_number, tel)
+values ('1a', '{noop}123qwe!@#', 'GOOGLE', 'ROLE_USER', 'a1@mail.com','참가자1', 1, '010-0000-0001');
+
+insert into members(id, password, provider, role, email, name, profile_image_number, tel)
+values ('2a', '{noop}123qwe!@#', 'GOOGLE', 'ROLE_USER', 'a2@mail.com','참가자2', 1, '010-0000-0002');
+
+insert into members(id, password, provider, role, email, name, profile_image_number, tel)
+values ('3a', '{noop}123qwe!@#', 'GOOGLE', 'ROLE_USER', 'a3@mail.com','참가자3', 1, '010-0000-0003');
+
+insert into members(id, password, provider, role, email, name, profile_image_number, tel)
+values ('4a', '{noop}123qwe!@#', 'GOOGLE', 'ROLE_USER', 'a4@mail.com','참가자4', 1, '010-0000-0004');
+
+insert into members(id, password, provider, role, email, name, profile_image_number, tel)
+values ('5a', '{noop}123qwe!@#', 'GOOGLE', 'ROLE_USER', 'a5@mail.com','참가자5', 1, '010-0000-0005');
+
+insert into members(id, password, provider, role, email, name, profile_image_number, tel)
+values ('6a', '{noop}123qwe!@#', 'GOOGLE', 'ROLE_USER', 'a6@mail.com','참가자6', 1, '010-0000-0006');
+
+insert into members(id, password, provider, role, email, name, profile_image_number, tel)
+values ('7a', '{noop}123qwe!@#', 'GOOGLE', 'ROLE_USER', 'a7@mail.com','참가자7', 1, '010-0000-0007');
+
+insert into members(id, password, provider, role, email, name, profile_image_number, tel)
+values ('8a', '{noop}123qwe!@#', 'GOOGLE', 'ROLE_USER', 'a8@mail.com','참가자8', 1, '010-0000-0008');
+
+insert into members(id, password, provider, role, email, name, profile_image_number, tel)
+values ('9a', '{noop}123qwe!@#', 'GOOGLE', 'ROLE_USER', 'a9@mail.com','참가자9', 1, '010-0000-0009');
+
+insert into members(id, password, provider, role, email, name, profile_image_number, tel)
+values ('10a', '{noop}123qwe!@#', 'GOOGLE', 'ROLE_USER', 'a10@mail.com','참가자10', 1, '010-0000-0010');
+
+
+
+-- 그룹 멤버 삽입 (참가자1: super leader)
+insert into group_members(id, role, member_id, team_id, group_admin)
+values (10001, 'GROUP_LEADER', '1a', 1, true);
+
+-- 나머지 GROUP_LEADER 1명 (참가자2, groupAdmin: false)
+insert into group_members(id, role, member_id, team_id, group_admin)
+values (10002, 'GROUP_LEADER', '2a', 1, false);
+
+-- 나머지 98명은 GROUP_MEMBER
+insert into group_members(id, role, member_id, team_id, group_admin)
+values (10003, 'GROUP_MEMBER', '3a', 1, false);
+
+insert into group_members(id, role, member_id, team_id, group_admin)
+values (10004, 'GROUP_MEMBER', '4a', 1, false);
+
+insert into group_members(id, role, member_id, team_id, group_admin)
+values (10005, 'GROUP_MEMBER', '5a', 1, false);
+
+insert into group_members(id, role, member_id, team_id, group_admin)
+values (10006, 'GROUP_MEMBER', '6a', 1, false);
+
+insert into group_members(id, role, member_id, team_id, group_admin)
+values (10007, 'GROUP_MEMBER', '7a', 1, false);
+
+insert into group_members(id, role, member_id, team_id, group_admin)
+values (10008, 'GROUP_MEMBER', '8a', 1, false);
+
+insert into group_members(id, role, member_id, team_id, group_admin)
+values (10009, 'GROUP_MEMBER', '9a', 1, false);
+
+insert into group_members(id, role, member_id, team_id, group_admin)
+values (10010, 'GROUP_MEMBER', '10a', 1, false);

--- a/src/test/java/com/grepp/spring/app/model/schedule/ScheduleCreateTest.java
+++ b/src/test/java/com/grepp/spring/app/model/schedule/ScheduleCreateTest.java
@@ -1,0 +1,159 @@
+package com.grepp.spring.app.model.schedule;
+
+import com.grepp.spring.app.controller.api.schedule.payload.request.CreateSchedulesRequest;
+import com.grepp.spring.app.model.event.code.MeetingType;
+import com.grepp.spring.app.model.event.repository.EventMemberRepository;
+import com.grepp.spring.app.model.event.service.EventCommandService;
+import com.grepp.spring.app.model.schedule.code.ScheduleStatus;
+import com.grepp.spring.app.model.schedule.dto.CreateScheduleMembersDto;
+import com.grepp.spring.app.model.schedule.entity.Schedule;
+import com.grepp.spring.app.model.schedule.repository.ScheduleCommandRepository;
+import com.grepp.spring.app.model.schedule.repository.ScheduleMemberCommandRepository;
+import com.grepp.spring.app.model.schedule.repository.ScheduleQueryRepository;
+import com.grepp.spring.app.model.schedule.service.ScheduleCommandService;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+public class ScheduleCreateTest {
+
+    @Autowired
+    private ScheduleCommandService scheduleCommandService;
+
+    @Autowired
+    private ScheduleCommandRepository scheduleCommandRepository;
+
+    @Autowired
+    private EventCommandService eventCommandService;
+
+    @Autowired
+    private EventMemberRepository eventMemberRepository;
+
+    @Autowired
+    private ScheduleQueryRepository scheduleQueryRepository;
+
+
+    @Autowired
+    private ScheduleMemberCommandRepository scheduleMemberCommandRepository;
+
+
+    @BeforeEach
+    void setUp() {
+        Long eventId = 4L;
+        Long groupId = 1L;
+
+        String currentMemberId = "";
+        for (int i = 1; i < 11; i++) {
+            currentMemberId = i + "a";
+            eventCommandService.joinEvent(eventId, groupId, currentMemberId);
+        }
+    }
+
+    @AfterEach
+    void restore() {
+        scheduleMemberCommandRepository.deleteAllInBatch();
+        scheduleCommandRepository.deleteAllInBatch();
+        eventMemberRepository.deleteAllInBatch();
+    }
+
+    @Nested
+    @DisplayName("일정 생성 (create) 테스트")
+    class CreateScheduleTests {
+
+        @Test
+        @DisplayName("멀티 스레드, 10명이 동시에 추가")
+        void multiRegistSchedule() throws InterruptedException {
+
+            int threadCount = 10;
+            Long eventId = 4L;
+
+            CreateSchedulesRequest request = CreateSchedulesRequest.builder()
+                .eventId(eventId)
+                .startTime(LocalDateTime.now().plusDays(1).withHour(9).withMinute(0).withSecond(0)
+                    .withNano(0))
+                .endTime(LocalDateTime.now().plusDays(1).withHour(11).withMinute(0).withSecond(0)
+                    .withNano(0))
+                .scheduleName("일정" + "1")
+                .description("무슨 일정? 일정" + "1")
+                .schedulesStatus(ScheduleStatus.L_RECOMMEND)
+                .meetingType(MeetingType.ONLINE)
+                .members(List.of(CreateScheduleMembersDto.builder().memberId("1a").build()))
+                .build();
+
+            // 스레드 풀과 동기화용 래치
+            ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+            CountDownLatch latch = new CountDownLatch(threadCount);
+
+            IntStream.rangeClosed(1, threadCount).forEach(i -> {
+                executor.submit(() -> {
+                    try {
+                        String currentMemberId = i + "a"; // "1a", "2a", ..., "100a"
+                        scheduleCommandService.createSchedule(request, currentMemberId);
+                    } catch (Exception e) {
+                        // 예외는 무시 (정원 초과 등)
+                        System.out.println(
+                            "Thread " + i + " failed: " + e.getClass().getSimpleName());
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            });
+
+            // 모든 쓰레드 종료 대기
+            latch.await();
+            executor.shutdown();
+
+            List<Schedule> schedules = scheduleQueryRepository.findAll();
+            System.out.println(schedules.size());
+            assertEquals(1, schedules.size());
+            assertEquals("일정1", schedules.get(0).getScheduleName());
+        }
+
+
+        @Test
+        @DisplayName("단일 스레드, 일정 생성 테스트")
+        void singleRegistSchedule() {
+
+            // given
+            Long eventId = 4L;
+            String memberId = "1a";
+            CreateSchedulesRequest request = CreateSchedulesRequest.builder()
+                .eventId(eventId)
+                .startTime(LocalDateTime.now().plusDays(1).withHour(9).withMinute(0).withSecond(0)
+                    .withNano(0))
+                .endTime(LocalDateTime.now().plusDays(1).withHour(11).withMinute(0).withSecond(0)
+                    .withNano(0))
+                .scheduleName("일정" + "1")
+                .description("무슨 일정? 일정" + "1")
+                .schedulesStatus(ScheduleStatus.L_RECOMMEND)
+                .meetingType(MeetingType.ONLINE)
+                .members(List.of(CreateScheduleMembersDto.builder().memberId("1a").build()))
+                .build();
+
+            // when
+            scheduleCommandService.createSchedule(request, memberId);
+
+            // then
+
+            List<Schedule> schedules = scheduleQueryRepository.findAll();
+            assertEquals(1, schedules.size());
+            assertEquals("일정1", schedules.get(0).getScheduleName());
+
+        }
+    }
+
+
+}


### PR DESCRIPTION
낙관적 락으로 해결


## ✅ 관련 이슈
- close #220

## 🛠️ 작업 내용
- 낙관적 락을 통해 하나의 이벤트에 대해 일정을 생성 하는 요청이 동시에 여러 개 들어 온 경우 하나의 스레드만 처리 후 나머지 스레드는 롤백

## 📸 스크린샷 (선택)
- <img width="987" height="904" alt="image" src="https://github.com/user-attachments/assets/4f6ab94d-18b6-482b-85d5-75eeb7720054" />
- 테스트 결과 5번 스레드만 일정을 추가하였고, 나머지 스레드들은 낙관적 락 예외에 걸리게 된다.

## 🧩 기타 참고사항
- 테스트 시 testForScheduleRegist.sql을 실행하여 db에 저장해야 함.
-  낙관적 락을 걸지 않아도 test에는 문제가 생기지 않음 -> DB상 데드락이 발생하고, 해당 데드락들은 mySQL의 innoDB엔진이 롤백으로 처리하여 문제는 없다. 
- 그렇다고 작성한 코드가 락을 컨트롤 대신 데드락에 의존하여 db엔진이 처리하길 바라면, 엔진이 바뀐다거나 로직이 조금만 바뀌어도 동시성 문제를 해결할 수 있다고 보장할 수 없다. -> 낙관적 락 적용
- 추후 일정의 Id를 요청 파라미터로 받고, 해당 일정의 status를 바꾸는 로직으로 변경 시 낙관적 락은 유효하지 않을 수 있다. -> 비관적 락으로 전환을 염두해야 함.
