### PR TITLE
♻️ refactor: event_members 테이블에 (event_id, member_id) 복합 인덱스 추가

### DIFF
--- a/src/main/resources/indexing_mysql.sql
+++ b/src/main/resources/indexing_mysql.sql
@@ -1,0 +1,29 @@
+-- 1. 인덱스 생성
+CREATE INDEX idx_event_members_event_member
+    ON event_members(event_id, member_id);
+
+# CREATE INDEX idx_event_members_event_activated
+#     ON event_members(event_id, confirmed);
+
+-- 2. 인덱스 확인 (MySQL에서는 SHOW INDEX 사용)
+SHOW INDEX FROM event_members;
+
+-- 3. 쿼리 성능 계획 확인
+EXPLAIN
+SELECT *
+FROM event_members
+WHERE event_id = 1
+  AND member_id = 'GOOGLE_115434652372556552718'
+    LIMIT 1;
+
+-- mysql 은 전체 강제 인덱싱 사용 옵션이 따로 없음.
+
+-- FORCE INDEX로 인덱스 유도 가능
+EXPLAIN
+SELECT *
+FROM event_members FORCE INDEX (idx_event_members_event_member)
+WHERE event_id = 1 AND member_id = 'GOOGLE_115434652372556552718'
+    LIMIT 1;
+
+
+SHOW INDEX FROM event_members;

--- a/src/main/resources/indexing_postgres.sql
+++ b/src/main/resources/indexing_postgres.sql
@@ -1,0 +1,30 @@
+-- 1. 인덱스 생성
+CREATE INDEX IF NOT EXISTS idx_event_members_event_member
+    ON event_members(event_id, member_id);
+
+-- CREATE INDEX IF NOT EXISTS idx_event_members_event_activated
+--     ON event_members(event_id, confirmed);
+
+-- 2. 인덱스 확인 (스키마 명시)
+SELECT *
+FROM pg_catalog.pg_indexes
+WHERE tablename = 'event_members';
+
+-- 3. 쿼리 성능 계획 확인
+EXPLAIN
+SELECT *
+FROM event_members
+WHERE event_id = 1
+  AND member_id = 'GOOGLE_115434652372556552718'
+LIMIT 1;
+
+-- 실제 쿼리에 인덱스 사용되는지 확인. 지금 row 1개라 자동으로 seq scan(full scan)
+EXPLAIN ANALYZE
+SELECT *
+FROM event_members
+WHERE event_id = 1
+  AND member_id = 'GOOGLE_115434652372556552718'
+LIMIT 1;
+
+-- 강제 인덱스 사용 유도
+SET enable_seqscan = OFF;


### PR DESCRIPTION
## ✅ 관련 이슈
- close #226 

## 🛠️ 작업 내용
- event_members 테이블에 (event_id, member_id) 복합 인덱스 추가
   - `WHERE event_id = ? AND member_id = ?`
- mysql, postgres 기준으로 파일 두개 생성

## 📸 스크린샷 (선택)
<img width="1050" height="140" alt="image" src="https://github.com/user-attachments/assets/6214cbf2-8bad-4bad-8671-31d927a766a8" />

- 활용 가능 키 (기본 조회(ex. `WHERE event_id = ?`)에서 단일 인덱스 event_id 를 활용한 상태)

<img width="1043" height="222" alt="image" src="https://github.com/user-attachments/assets/0d4d4130-a2f8-4952-9e6f-9fdbe9450cef" />

- 복합 인덱스 생성 전 기본 상태 (FK 제약 조건에 의해 `event_id` & `member_id` 에 대한 단일 인덱스 자동 생성됨)

<img width="1535" height="1475" alt="image" src="https://github.com/user-attachments/assets/ca003fc7-1cb8-49aa-8c22-64a92f897841" />
- 인덱스 적용 후 postman 테스트 및 개선 결과 확인

## 🧩 기타 참고사항
- 기존에는 FK 제약조건으로 생성된 단일 인덱스(`event_id`, `member_id` 각각)에만 의존
- confirmed 는 DB 의 WHERE 조건에 직접 사용되지 않고,  `false` 값(시간 확정  사용자)도 똑같이 조회에 활용되기에 인덱스에 활용 X
~현재 쿼리 로그 기준, `event_id + activated` 조건이 더 자주 조회됨,~
~그러나, 대부분의 row가 `activated = true` 상태이기 때문에 선택도가 낮아 인덱스 활용도가 떨어질 수 있다고 판단~
- `event_id + activated` 자주 조회되기 때문에 추가.
- `event_id + member_id`는 선택도가 높고 단건 조회에도 직접 사용되므로 우선적으로 인덱스를 추가.
- mysql 파일의 CREATE 에 해당하는 쿼리문 두 줄 실행 부탁드립니다.
<img width="992" height="284" alt="image" src="https://github.com/user-attachments/assets/b549dde3-4969-47f2-a466-a7f8399baede" />