### PR TITLE
🐛 fix: ScheduleQueryService 메서드에 Transectional Read Only 적용

### DIFF
--- a/src/main/java/com/grepp/spring/app/model/event/entity/Event.java
+++ b/src/main/java/com/grepp/spring/app/model/event/entity/Event.java
@@ -82,8 +82,8 @@ public class Event extends BaseEntity {
         if (title == null || title.trim().isEmpty()) {
             throw new IllegalArgumentException("이벤트 제목은 필수입니다.");
         }
-        if (title.length() > 10) {
-            throw new IllegalArgumentException("이벤트 제목은 10자를 초과할 수 없습니다.");
+        if (title.length() > 20) {
+            throw new IllegalArgumentException("이벤트 제목은 20자를 초과할 수 없습니다.");
         }
     }
 

--- a/src/main/java/com/grepp/spring/app/model/schedule/service/ScheduleQueryService.java
+++ b/src/main/java/com/grepp/spring/app/model/schedule/service/ScheduleQueryService.java
@@ -80,6 +80,7 @@ public class ScheduleQueryService {
         throw new NotScheduleMemberException(ScheduleErrorCode.NOT_SCHEDULE_MEMBER);
     }
 
+    @Transactional(readOnly = true)
     public ShowSuggestedLocationsResponse showSuggestedLocation(Long scheduleId) {
         List<MetroInfoDto> infoDto = getMetroInfoDtos(scheduleId);
         int scheduleMemberNumber = scheduleMemberQueryRepository.findByScheduleId(scheduleId).size();
@@ -114,6 +115,7 @@ public class ScheduleQueryService {
         return departLocationCount;
     }
 
+    @Transactional(readOnly = true)
     public ShowVoteMembersResponse findVoteMembers(Long scheduleId) {
 
         List<VoteMemberDto> voteMemberList = getVoteMemberDtos(scheduleId);
@@ -138,29 +140,34 @@ public class ScheduleQueryService {
         return voteMemberList;
     }
 
+    @Transactional(readOnly = true)
     public Schedule findScheduleById(Long scheduleId) {
         return scheduleQueryRepository.findById(scheduleId)
             .orElseThrow(() -> new ScheduleNotFoundException(
                 GroupErrorCode.SCHEDULE_NOT_FOUND));
     }
 
+    @Transactional(readOnly = true)
     public Event findEventById(Long eventId) {
         return eventRepository.findById(eventId).orElseThrow(() -> new EventNotFoundException(
             EventErrorCode.EVENT_NOT_FOUND));
     }
 
+    @Transactional(readOnly = true)
     public Location findLocationById(Long locationId) {
         return locationQueryRepository.findById(locationId)
             .orElseThrow(() -> new LocationNotFoundException(
                 ScheduleErrorCode.LOCATION_NOT_FOUND));
     }
 
+    @Transactional(readOnly = true)
     public ScheduleMember findScheduleMemberById(Long scheduleMemberId) {
         return scheduleMemberQueryRepository.findById(scheduleMemberId)
             .orElseThrow(() -> new ScheduleMemberNotFoundException(
                 ScheduleErrorCode.LOCATION_NOT_FOUND));
     }
 
+    @Transactional(readOnly = true)
     public Workspace findWorkspaceById(Long workspaceId) {
         return workspaceQueryRepository.findById(workspaceId).orElseThrow(
             () -> new WorkSpaceNotFoundException(ScheduleErrorCode.WORKSPACE_NOT_FOUND));


### PR DESCRIPTION
## ✅ 관련 이슈
- close #234 

## 🛠️ 작업 내용
- ScheduleQueryService의 Transection ReadOnly 적용

## 📸 스크린샷 (선택)
- DB에는 정상적으로 투표한 사람의 ID와 Location ID가 저장되어 있음
<img width="1370" height="59" alt="image" src="https://github.com/user-attachments/assets/293b0545-edcb-45b3-9519-95f2f7a712b8" />
- 다만 일정 정보 조회 시에 출력되는 멤버 정보에서, 각 멤버의 투표 장소가 정상적으로 출력되지 않음
- DB에서는 혜주님이 투표를 했지만 API 호출 시 NULL로 저장되고, 달라이라마가 NULL이어야 하지만 다른 값이 붙어있음.
<img width="516" height="944" alt="image" src="https://github.com/user-attachments/assets/4e083707-3ab8-4e17-9ab5-0c0c82889cba" />


## 🧩 기타 참고사항
- Transection Read Only를 생활화합시다.
