### PR TITLE
♻️ refactor: Observer 패턴을 적용하여 회원 탈퇴 로직 개선

### DIFF
--- a/src/main/java/com/grepp/spring/app/model/group/service/GroupCommandService.java
+++ b/src/main/java/com/grepp/spring/app/model/group/service/GroupCommandService.java
@@ -17,6 +17,7 @@ import com.grepp.spring.app.model.group.repository.GroupCommandRepository;
 import com.grepp.spring.app.model.group.repository.GroupMemberCommandRepository;
 import com.grepp.spring.app.model.group.repository.GroupMemberRepository;
 import com.grepp.spring.app.model.member.entity.Member;
+import com.grepp.spring.app.model.member.event.MemberWithdrawalEvent;
 import com.grepp.spring.app.model.member.repository.MemberRepository;
 import com.grepp.spring.app.model.schedule.code.ScheduleRole;
 import com.grepp.spring.app.model.schedule.entity.Schedule;
@@ -38,6 +39,7 @@ import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
@@ -430,6 +432,14 @@ public class GroupCommandService {
             // 그룹멤버 조회 - 403 NOT_GROUP_MEMBER 예외 처리
             GroupMember groupMember = findGroupMemberOrThrow(request.getGroupId(), member1.getId());
         }
+    }
+
+    // 회원 탈퇴 이벤트 리스너
+    @EventListener
+    @Transactional
+    public void handleMemberWithdrawal(MemberWithdrawalEvent event) {
+        Member member = event.getMember();
+        handleGroupWithdrawal(member);
     }
 
     // 회원 탈퇴 중 그룹 관련 처리 메서드

--- a/src/main/java/com/grepp/spring/app/model/member/event/MemberWithdrawalEvent.java
+++ b/src/main/java/com/grepp/spring/app/model/member/event/MemberWithdrawalEvent.java
@@ -1,0 +1,16 @@
+package com.grepp.spring.app.model.member.event;
+
+import com.grepp.spring.app.model.member.entity.Member;
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+@Getter
+public class MemberWithdrawalEvent extends ApplicationEvent {
+
+    private final Member member;
+
+    public MemberWithdrawalEvent(Object source, Member member) {
+        super(source);
+        this.member = member;
+    }
+}

--- a/src/main/java/com/grepp/spring/app/model/schedule/service/ScheduleCommandService.java
+++ b/src/main/java/com/grepp/spring/app/model/schedule/service/ScheduleCommandService.java
@@ -8,6 +8,7 @@ import com.grepp.spring.app.controller.api.schedule.payload.response.CreateOnlin
 import com.grepp.spring.app.controller.api.schedule.payload.response.CreateSchedulesResponse;
 import com.grepp.spring.app.model.event.entity.Event;
 import com.grepp.spring.app.model.member.entity.Member;
+import com.grepp.spring.app.model.member.event.MemberWithdrawalEvent;
 import com.grepp.spring.app.model.member.repository.MemberRepository;
 import com.grepp.spring.app.model.schedule.code.MeetingPlatform;
 import com.grepp.spring.app.model.schedule.code.ScheduleRole;
@@ -29,6 +30,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.event.EventListener;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -553,6 +555,14 @@ public class ScheduleCommandService {
             location = locationCommandRepository.save(location);
         }
         return location;
+    }
+
+    // 회원 탈퇴 이벤트 리스너
+    @EventListener
+    @Transactional
+    public void handleMemberWithdrawal(MemberWithdrawalEvent event) {
+        Member member = event.getMember();
+        handleScheduleWithdrawal(member);
     }
 
     // 회원 탈퇴 중 일정 관련 처리 메서드


### PR DESCRIPTION
## ✅ 관련 이슈
- close #257 

## 🛠️ 작업 내용
- 회원 탈퇴 로직의 서비스 간 결합도를 낮추기 위해 Observer 패턴을 적용하여 리팩토링을 진행

- AS-IS
  - MemberService의 withdraw 메서드가 회원 탈퇴 시 필요한 후속 처리를 위해 GroupCommandService, ScheduleCommandService 등 다른 서비스의 메서드를 직접 호출
  - MemberService가 다른 도메인의 탈퇴 처리 로직까지 알아야 하는 강한 결합 구조가 형성됨
  - 향후 회원 탈퇴와 관련된 새로운 기능이 추가될 때마다 MemberService의 수정이 불가피하여 OCP 원칙을 위반할 가능성이 높음

- TO-BE
  - Spring의 이벤트 메커니즘(ApplicationEventPublisher)을 활용하여 Observer 패턴을 구현
  - MemberService: 이제 회원 탈퇴 시 MemberWithdrawalEvent라는 이벤트를 발행하는 역할만 수행 -> 더 이상 그룹이나 일정 서비스에 직접 의존하지 않음
  - GroupCommandService & ScheduleCommandService: 각각 EventListener를 통해 MemberWithdrawalEvent를 구독. 이벤트가 발생하면, 각 서비스는 자신에게 필요한 작업(예: 그룹 데이터 정리, 일정 마스터 위임)을 독립적으로 수행


## 📸 스크린샷
withdraw.sql 상황에서 5a 사용자가 회원 탈퇴
<img width="1203" height="86" alt="image" src="https://github.com/user-attachments/assets/d06816d9-8f1e-488b-9a62-4d4219d4a0b7" />

